### PR TITLE
Add support for incremental timing updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,8 @@ callgrind*
 # Python temp files
 #
 *.pyc
+
+#Generated Tatum files
+*.rpt
+*.dot
+*.echo

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,8 +20,13 @@ if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
     #Only set compiler flags if not a sub-project
     set(WARN_FLAGS -Wall -Wextra -Wpedantic -Wcast-qual -Wcast-align -Wshadow -Wformat=2 -Wlogical-op -Wmissing-declarations -Wmissing-include-dirs -Wredundant-decls -Wswitch-default -Wundef -Wunused-variable -Wdisabled-optimization -Wnoexcept -Woverloaded-virtual -Wctor-dtor-privacy -Wnon-virtual-dtor)
 
+    set(SANITIZE_FLAGS  -fsanitize=address -fsanitize=leak -fsanitize=undefined)
+
     add_compile_options(${WARN_FLAGS})
     add_compile_options(-std=c++14)
+
+    #add_compile_options(${SANITIZE_FLAGS})
+    #link_libraries(${SANITIZE_FLAGS})
 
     set(FLEX_BISON_WARN_SUPPRESS_FLAGS -Wno-switch-default -Wno-unused-parameter -Wno-sign-compare -Wno-missing-declarations)
 endif()

--- a/libtatum/tatum/HoldAnalysis.hpp
+++ b/libtatum/tatum/HoldAnalysis.hpp
@@ -65,7 +65,9 @@ class HoldAnalysis : public detail::CommonAnalysisVisitor<detail::HoldAnalysisOp
 
         TimingTags::tag_range hold_tags(const NodeId node) const { return ops_.get_tags(node); }
         TimingTags::tag_range hold_tags(const NodeId node, TagType type) const { return ops_.get_tags(node, type); }
+#ifdef TATUM_CALCULATE_EDGE_SLACKS
         TimingTags::tag_range hold_edge_slacks(const EdgeId edge) const { return ops_.get_edge_slacks(edge); }
+#endif
         TimingTags::tag_range hold_node_slacks(const NodeId node) const { return ops_.get_node_slacks(node); }
 };
 

--- a/libtatum/tatum/SetupAnalysis.hpp
+++ b/libtatum/tatum/SetupAnalysis.hpp
@@ -132,7 +132,9 @@ class SetupAnalysis : public detail::CommonAnalysisVisitor<detail::SetupAnalysis
 
         TimingTags::tag_range setup_tags(const NodeId node) const { return ops_.get_tags(node); }
         TimingTags::tag_range setup_tags(const NodeId node, TagType type) const { return ops_.get_tags(node, type); }
+#ifdef TATUM_CALCULATE_EDGE_SLACKS
         TimingTags::tag_range setup_edge_slacks(const EdgeId edge) const { return ops_.get_edge_slacks(edge); }
+#endif
         TimingTags::tag_range setup_node_slacks(const NodeId node) const { return ops_.get_node_slacks(node); }
 };
 

--- a/libtatum/tatum/SetupHoldAnalysis.hpp
+++ b/libtatum/tatum/SetupHoldAnalysis.hpp
@@ -44,6 +44,16 @@ class SetupHoldAnalysis : public GraphVisitor {
             hold_visitor_.do_reset_node_required_tags(node_id); 
         }
 
+        void do_reset_node_arrival_tags_from_origin(const NodeId node_id, const NodeId origin) override { 
+            setup_visitor_.do_reset_node_arrival_tags_from_origin(node_id, origin); 
+            hold_visitor_.do_reset_node_arrival_tags_from_origin(node_id, origin); 
+        }
+
+        void do_reset_node_required_tags_from_origin(const NodeId node_id, const NodeId origin) override { 
+            setup_visitor_.do_reset_node_required_tags_from_origin(node_id, origin); 
+            hold_visitor_.do_reset_node_required_tags_from_origin(node_id, origin); 
+        }
+
         bool do_arrival_pre_traverse_node(const TimingGraph& tg, const TimingConstraints& tc, const NodeId node_id) override { 
             bool setup_unconstrained = setup_visitor_.do_arrival_pre_traverse_node(tg, tc, node_id); 
             bool hold_unconstrained = hold_visitor_.do_arrival_pre_traverse_node(tg, tc, node_id); 

--- a/libtatum/tatum/SetupHoldAnalysis.hpp
+++ b/libtatum/tatum/SetupHoldAnalysis.hpp
@@ -47,19 +47,25 @@ class SetupHoldAnalysis : public GraphVisitor {
             return setup_unconstrained || hold_unconstrained;
         }
 
-        void do_arrival_traverse_node(const TimingGraph& tg, const TimingConstraints& tc, const DelayCalculator& dc, const NodeId node_id) override { 
-            setup_visitor_.do_arrival_traverse_node(tg, tc, dc, node_id); 
-            hold_visitor_.do_arrival_traverse_node(tg, tc, dc, node_id); 
+        bool do_arrival_traverse_node(const TimingGraph& tg, const TimingConstraints& tc, const DelayCalculator& dc, const NodeId node_id) override { 
+            bool setup_modified = setup_visitor_.do_arrival_traverse_node(tg, tc, dc, node_id); 
+            bool hold_modified = hold_visitor_.do_arrival_traverse_node(tg, tc, dc, node_id); 
+
+            return setup_modified || hold_modified;
         }
 
-        void do_required_traverse_node(const TimingGraph& tg, const TimingConstraints& tc, const DelayCalculator& dc, const NodeId node_id) override { 
-            setup_visitor_.do_required_traverse_node(tg, tc, dc, node_id); 
-            hold_visitor_.do_required_traverse_node(tg, tc, dc, node_id); 
+        bool do_required_traverse_node(const TimingGraph& tg, const TimingConstraints& tc, const DelayCalculator& dc, const NodeId node_id) override { 
+            bool setup_modified = setup_visitor_.do_required_traverse_node(tg, tc, dc, node_id); 
+            bool hold_modified = hold_visitor_.do_required_traverse_node(tg, tc, dc, node_id); 
+
+            return setup_modified || hold_modified;
         }
         
-        void do_slack_traverse_node(const TimingGraph& tg, const DelayCalculator& dc, const NodeId node) override {
-            setup_visitor_.do_slack_traverse_node(tg, dc, node); 
-            hold_visitor_.do_slack_traverse_node(tg, dc, node); 
+        bool do_slack_traverse_node(const TimingGraph& tg, const DelayCalculator& dc, const NodeId node) override {
+            bool setup_modified = setup_visitor_.do_slack_traverse_node(tg, dc, node); 
+            bool hold_modified = hold_visitor_.do_slack_traverse_node(tg, dc, node); 
+
+            return setup_modified || hold_modified;
         }
 
         TimingTags::tag_range setup_tags(const NodeId node_id) const { return setup_visitor_.setup_tags(node_id); }

--- a/libtatum/tatum/SetupHoldAnalysis.hpp
+++ b/libtatum/tatum/SetupHoldAnalysis.hpp
@@ -29,10 +29,12 @@ class SetupHoldAnalysis : public GraphVisitor {
             hold_visitor_.do_reset_node(node_id); 
         }
 
+#ifdef TATUM_CALCULATE_EDGE_SLACKS
         void do_reset_edge(const EdgeId edge_id) override { 
             setup_visitor_.do_reset_edge(edge_id); 
             hold_visitor_.do_reset_edge(edge_id); 
         }
+#endif
 
         void do_reset_node_arrival_tags(const NodeId node_id) override { 
             setup_visitor_.do_reset_node_arrival_tags(node_id); 
@@ -96,12 +98,16 @@ class SetupHoldAnalysis : public GraphVisitor {
 
         TimingTags::tag_range setup_tags(const NodeId node_id) const { return setup_visitor_.setup_tags(node_id); }
         TimingTags::tag_range setup_tags(const NodeId node_id, TagType type) const { return setup_visitor_.setup_tags(node_id, type); }
+#ifdef TATUM_CALCULATE_EDGE_SLACKS
         TimingTags::tag_range setup_edge_slacks(const EdgeId edge_id) const { return setup_visitor_.setup_edge_slacks(edge_id); }
+#endif
         TimingTags::tag_range setup_node_slacks(const NodeId node_id) const { return setup_visitor_.setup_node_slacks(node_id); }
 
         TimingTags::tag_range hold_tags(const NodeId node_id) const { return hold_visitor_.hold_tags(node_id); }
         TimingTags::tag_range hold_tags(const NodeId node_id, TagType type) const { return hold_visitor_.hold_tags(node_id, type); }
+#ifdef TATUM_CALCULATE_EDGE_SLACKS
         TimingTags::tag_range hold_edge_slacks(const EdgeId edge_id) const { return hold_visitor_.hold_edge_slacks(edge_id); }
+#endif
         TimingTags::tag_range hold_node_slacks(const NodeId node_id) const { return hold_visitor_.hold_node_slacks(node_id); }
 
         SetupAnalysis& setup_visitor() { return setup_visitor_; }

--- a/libtatum/tatum/SetupHoldAnalysis.hpp
+++ b/libtatum/tatum/SetupHoldAnalysis.hpp
@@ -28,9 +28,20 @@ class SetupHoldAnalysis : public GraphVisitor {
             setup_visitor_.do_reset_node(node_id); 
             hold_visitor_.do_reset_node(node_id); 
         }
+
         void do_reset_edge(const EdgeId edge_id) override { 
             setup_visitor_.do_reset_edge(edge_id); 
             hold_visitor_.do_reset_edge(edge_id); 
+        }
+
+        void do_reset_node_arrival_tags(const NodeId node_id) override { 
+            setup_visitor_.do_reset_node_arrival_tags(node_id); 
+            hold_visitor_.do_reset_node_arrival_tags(node_id); 
+        }
+
+        void do_reset_node_required_tags(const NodeId node_id) override { 
+            setup_visitor_.do_reset_node_required_tags(node_id); 
+            hold_visitor_.do_reset_node_required_tags(node_id); 
         }
 
         bool do_arrival_pre_traverse_node(const TimingGraph& tg, const TimingConstraints& tc, const NodeId node_id) override { 

--- a/libtatum/tatum/SetupHoldAnalysis.hpp
+++ b/libtatum/tatum/SetupHoldAnalysis.hpp
@@ -44,6 +44,11 @@ class SetupHoldAnalysis : public GraphVisitor {
             hold_visitor_.do_reset_node_required_tags(node_id); 
         }
 
+        void do_reset_node_slack_tags(const NodeId node_id) override { 
+            setup_visitor_.do_reset_node_slack_tags(node_id); 
+            hold_visitor_.do_reset_node_slack_tags(node_id); 
+        }
+
         void do_reset_node_arrival_tags_from_origin(const NodeId node_id, const NodeId origin) override { 
             setup_visitor_.do_reset_node_arrival_tags_from_origin(node_id, origin); 
             hold_visitor_.do_reset_node_arrival_tags_from_origin(node_id, origin); 

--- a/libtatum/tatum/TimingGraph.cpp
+++ b/libtatum/tatum/TimingGraph.cpp
@@ -356,7 +356,7 @@ void TimingGraph::force_levelize() {
             if (node_type(node_id) == NodeType::SOURCE) {
                 //We require that all primary inputs (i.e. top-level circuit inputs) to
                 //be SOURCEs. Due to disconnected nodes we may have non-SOURCEs which 
-                //appear in the first level.
+                //otherwise appear in the first level.
                 primary_inputs_.push_back(node_id);
             }
         }
@@ -370,6 +370,8 @@ void TimingGraph::force_levelize() {
     //to the current level.
     int level_idx = 0;
     level_ids_.emplace_back(level_idx);
+
+    std::vector<NodeId> last_level;
 
     bool inserted_node_in_level = true;
     while(inserted_node_in_level) { //If nothing was inserted we are finished
@@ -388,13 +390,27 @@ void TimingGraph::force_levelize() {
 
                 //Add to the next level if all fanin has been seen
                 if(node_fanin_remaining[size_t(sink_node)] == 0) {
-                    //Ensure there is space by allocating the next level if required
-                    level_nodes_.resize(level_idx+2);
 
-                    //Add the node
-                    level_nodes_[LevelId(level_idx+1)].push_back(sink_node);
+                    if (node_out_edges(sink_node).size() != 0) {
+                        //Place into next level
+                        
+                        //Ensure there is space by allocating the next level if required
+                        level_nodes_.resize(level_idx+2);
 
-                    inserted_node_in_level = true;
+                        //Add the node
+                        level_nodes_[LevelId(level_idx+1)].push_back(sink_node);
+
+                        inserted_node_in_level = true;
+                    } else {
+                        //No fan-out
+                        //
+                        //We choose to put these nodes into the *last* level,
+                        //since it makes it easier to walk back from them in the
+                        //required time traversal
+                        TATUM_ASSERT(node_out_edges(sink_node).size() == 0);
+                        
+                        last_level.push_back(sink_node);
+                    }
                 }
             }
 
@@ -415,6 +431,11 @@ void TimingGraph::force_levelize() {
             level_ids_.emplace_back(level_idx);
         }
     }
+
+    //Add the last level to the end of the levelization
+    level_nodes_.emplace_back(last_level);
+    level_idx++;
+    level_ids_.emplace_back(level_idx);
 
     //Mark the levelization as valid
     is_levelized_ = true;

--- a/libtatum/tatum/TimingGraph.cpp
+++ b/libtatum/tatum/TimingGraph.cpp
@@ -447,8 +447,8 @@ void TimingGraph::force_levelize() {
 
     //Build the reverse node-to-level look-up
     node_levels_.resize(nodes().size());
-    for (LevelId level : levels()) {
-        for(NodeId node : level_nodes(level)) {
+    for (LevelId level : level_ids_) {
+        for(NodeId node : level_nodes_[level]) {
             node_levels_[node] = level;
         }
     }

--- a/libtatum/tatum/TimingGraph.cpp
+++ b/libtatum/tatum/TimingGraph.cpp
@@ -421,17 +421,6 @@ void TimingGraph::force_levelize() {
                     }
                 }
             }
-
-            //Also track the primary outputs (those with fan-in AND no fan-out)
-            //
-            // There may be some node with neither any fan-in or fan-out. 
-            // We will treat them as primary inputs, so they should not be to
-            // the primary outputs
-            if(   node_out_edges(node_id).size() == 0 
-               && node_in_edges(node_id).size() != 0
-               && node_type(node_id) == NodeType::SINK) {
-                logical_outputs_.push_back(node_id);
-            }
         }
 
         if(inserted_node_in_level) {
@@ -444,6 +433,8 @@ void TimingGraph::force_levelize() {
     level_nodes_.emplace_back(last_level);
     level_idx++;
     level_ids_.emplace_back(level_idx);
+
+    logical_outputs_ = std::move(last_level);
 
     //Build the reverse node-to-level look-up
     node_levels_.resize(nodes().size());

--- a/libtatum/tatum/TimingGraph.cpp
+++ b/libtatum/tatum/TimingGraph.cpp
@@ -434,7 +434,13 @@ void TimingGraph::force_levelize() {
     level_idx++;
     level_ids_.emplace_back(level_idx);
 
-    logical_outputs_ = std::move(last_level);
+    //Add SINK type nodes in the last level to logical outputs
+    //Note that we only do this for sinks, since non-sink nodes may end up
+    //in the last level (e.g. due to breaking combinational loops)
+    auto is_sink = [this](NodeId id) {
+        return this->node_type(id) == NodeType::SINK;
+    };
+    std::copy_if(last_level.begin(), last_level.end(), std::back_inserter(logical_outputs_), is_sink);
 
     //Build the reverse node-to-level look-up
     node_levels_.resize(nodes().size());

--- a/libtatum/tatum/TimingGraph.hpp
+++ b/libtatum/tatum/TimingGraph.hpp
@@ -104,6 +104,10 @@ class TimingGraph {
         ///\returns The edge id corresponding to the incoming clock launch edge, or EdgeId::INVALID() if none
         EdgeId node_clock_launch_edge(const NodeId id) const;
 
+        ///\param id The node id
+        ///\returns The level id corresponding to specified node
+        LevelId node_level(const NodeId id) const;
+
         /*
          * Edge accessors
          */
@@ -280,6 +284,7 @@ class TimingGraph {
         tatum::util::linear_map<NodeId,NodeType> node_types_; //Type of node
         tatum::util::linear_map<NodeId,std::vector<EdgeId>> node_in_edges_; //Incomiing edge IDs for node
         tatum::util::linear_map<NodeId,std::vector<EdgeId>> node_out_edges_; //Out going edge IDs for node
+        tatum::util::linear_map<NodeId,LevelId> node_levels_; //Out going edge IDs for node
 
         //Edge data
         tatum::util::linear_map<EdgeId,EdgeId> edge_ids_; //The edge IDs in the graph

--- a/libtatum/tatum/analyzer_factory.hpp
+++ b/libtatum/tatum/analyzer_factory.hpp
@@ -130,6 +130,37 @@ struct AnalyzerFactory<SetupHoldAnalysis,GraphWalker> {
     }
 };
 
+
+//Specialize for incremental setup
+template<>
+struct AnalyzerFactory<SetupAnalysis,SerialIncrWalker> {
+
+    static std::unique_ptr<SetupTimingAnalyzer> make(const TimingGraph& timing_graph,
+                                                         const TimingConstraints& timing_constraints,
+                                                         const DelayCalculator& delay_calc) {
+        return std::unique_ptr<SetupTimingAnalyzer>(
+                new detail::IncrSetupTimingAnalyzer<SerialIncrWalker>(timing_graph, 
+                                                                      timing_constraints, 
+                                                                      delay_calc)
+                );
+    }
+};
+
+//Specialize for incremental hold
+template<>
+struct AnalyzerFactory<HoldAnalysis,SerialIncrWalker> {
+
+    static std::unique_ptr<HoldTimingAnalyzer> make(const TimingGraph& timing_graph,
+                                                         const TimingConstraints& timing_constraints,
+                                                         const DelayCalculator& delay_calc) {
+        return std::unique_ptr<HoldTimingAnalyzer>(
+                new detail::IncrHoldTimingAnalyzer<SerialIncrWalker>(timing_graph, 
+                                                                     timing_constraints, 
+                                                                     delay_calc)
+                );
+    }
+};
+
 //Specialize for combined incremental setup and hold
 template<>
 struct AnalyzerFactory<SetupHoldAnalysis,SerialIncrWalker> {

--- a/libtatum/tatum/analyzer_factory.hpp
+++ b/libtatum/tatum/analyzer_factory.hpp
@@ -10,6 +10,7 @@
 #include "tatum/graph_walkers.hpp"
 #include "tatum/timing_analyzers.hpp"
 #include "tatum/analyzers/full_timing_analyzers.hpp"
+#include "tatum/analyzers/incr_timing_analyzers.hpp"
 
 namespace tatum {
 
@@ -125,6 +126,21 @@ struct AnalyzerFactory<SetupHoldAnalysis,GraphWalker> {
                 new detail::FullSetupHoldTimingAnalyzer<GraphWalker>(timing_graph, 
                                                                      timing_constraints, 
                                                                      delay_calc)
+                );
+    }
+};
+
+//Specialize for combined incremental setup and hold
+template<>
+struct AnalyzerFactory<SetupHoldAnalysis,SerialIncrWalker> {
+
+    static std::unique_ptr<SetupHoldTimingAnalyzer> make(const TimingGraph& timing_graph,
+                                                         const TimingConstraints& timing_constraints,
+                                                         const DelayCalculator& delay_calc) {
+        return std::unique_ptr<SetupHoldTimingAnalyzer>(
+                new detail::IncrSetupHoldTimingAnalyzer<SerialIncrWalker>(timing_graph, 
+                                                                          timing_constraints, 
+                                                                          delay_calc)
                 );
     }
 };

--- a/libtatum/tatum/analyzers/FullHoldTimingAnalyzer.hpp
+++ b/libtatum/tatum/analyzers/FullHoldTimingAnalyzer.hpp
@@ -57,6 +57,10 @@ class FullHoldTimingAnalyzer : public HoldTimingAnalyzer {
             graph_walker_.set_profiling_data("num_full_updates", graph_walker_.get_profiling_data("num_full_updates") + 1);
         }
 
+        virtual void invalidate_edge_impl(const EdgeId edge) override {
+            graph_walker_.invalidate_edge(edge);
+        }
+
         double get_profiling_data_impl(std::string key) const override { return graph_walker_.get_profiling_data(key); }
         size_t num_unconstrained_startpoints_impl() const override { return graph_walker_.num_unconstrained_startpoints(); }
         size_t num_unconstrained_endpoints_impl() const override { return graph_walker_.num_unconstrained_endpoints(); }

--- a/libtatum/tatum/analyzers/FullHoldTimingAnalyzer.hpp
+++ b/libtatum/tatum/analyzers/FullHoldTimingAnalyzer.hpp
@@ -61,6 +61,10 @@ class FullHoldTimingAnalyzer : public HoldTimingAnalyzer {
             graph_walker_.invalidate_edge(edge);
         }
 
+        virtual node_range modified_nodes_impl() const override {
+            return graph_walker_.modified_nodes();
+        }
+
         double get_profiling_data_impl(std::string key) const override { return graph_walker_.get_profiling_data(key); }
         size_t num_unconstrained_startpoints_impl() const override { return graph_walker_.num_unconstrained_startpoints(); }
         size_t num_unconstrained_endpoints_impl() const override { return graph_walker_.num_unconstrained_endpoints(); }

--- a/libtatum/tatum/analyzers/FullHoldTimingAnalyzer.hpp
+++ b/libtatum/tatum/analyzers/FullHoldTimingAnalyzer.hpp
@@ -71,7 +71,9 @@ class FullHoldTimingAnalyzer : public HoldTimingAnalyzer {
 
         TimingTags::tag_range hold_tags_impl(NodeId node_id) const override { return hold_visitor_.hold_tags(node_id); }
         TimingTags::tag_range hold_tags_impl(NodeId node_id, TagType type) const override { return hold_visitor_.hold_tags(node_id, type); }
+#ifdef TATUM_CALCULATE_EDGE_SLACKS
         TimingTags::tag_range hold_edge_slacks_impl(EdgeId edge_id) const override { return hold_visitor_.hold_edge_slacks(edge_id); }
+#endif
         TimingTags::tag_range hold_node_slacks_impl(NodeId node_id) const override { return hold_visitor_.hold_node_slacks(node_id); }
 
     private:

--- a/libtatum/tatum/analyzers/FullSetupHoldTimingAnalyzer.hpp
+++ b/libtatum/tatum/analyzers/FullSetupHoldTimingAnalyzer.hpp
@@ -82,6 +82,10 @@ class FullSetupHoldTimingAnalyzer : public SetupHoldTimingAnalyzer {
             graph_walker_.do_update_slack(timing_graph_, delay_calculator_, hold_visitor);
         }
 
+        virtual void invalidate_edge_impl(const EdgeId edge) override {
+            graph_walker_.invalidate_edge(edge);
+        }
+
         double get_profiling_data_impl(std::string key) const override { return graph_walker_.get_profiling_data(key); }
         size_t num_unconstrained_startpoints_impl() const override { return graph_walker_.num_unconstrained_startpoints(); }
         size_t num_unconstrained_endpoints_impl() const override { return graph_walker_.num_unconstrained_endpoints(); }

--- a/libtatum/tatum/analyzers/FullSetupHoldTimingAnalyzer.hpp
+++ b/libtatum/tatum/analyzers/FullSetupHoldTimingAnalyzer.hpp
@@ -86,6 +86,10 @@ class FullSetupHoldTimingAnalyzer : public SetupHoldTimingAnalyzer {
             graph_walker_.invalidate_edge(edge);
         }
 
+        virtual node_range modified_nodes_impl() const override {
+            return graph_walker_.modified_nodes();
+        }
+
         double get_profiling_data_impl(std::string key) const override { return graph_walker_.get_profiling_data(key); }
         size_t num_unconstrained_startpoints_impl() const override { return graph_walker_.num_unconstrained_startpoints(); }
         size_t num_unconstrained_endpoints_impl() const override { return graph_walker_.num_unconstrained_endpoints(); }

--- a/libtatum/tatum/analyzers/FullSetupHoldTimingAnalyzer.hpp
+++ b/libtatum/tatum/analyzers/FullSetupHoldTimingAnalyzer.hpp
@@ -96,12 +96,16 @@ class FullSetupHoldTimingAnalyzer : public SetupHoldTimingAnalyzer {
 
         TimingTags::tag_range setup_tags_impl(NodeId node_id) const override { return setup_hold_visitor_.setup_tags(node_id); }
         TimingTags::tag_range setup_tags_impl(NodeId node_id, TagType type) const override { return setup_hold_visitor_.setup_tags(node_id, type); }
+#ifdef TATUM_CALCULATE_EDGE_SLACKS
         TimingTags::tag_range setup_edge_slacks_impl(EdgeId edge_id) const override { return setup_hold_visitor_.setup_edge_slacks(edge_id); }
+#endif
         TimingTags::tag_range setup_node_slacks_impl(NodeId node_id) const override { return setup_hold_visitor_.setup_node_slacks(node_id); }
 
         TimingTags::tag_range hold_tags_impl(NodeId node_id) const override { return setup_hold_visitor_.hold_tags(node_id); }
         TimingTags::tag_range hold_tags_impl(NodeId node_id, TagType type) const override { return setup_hold_visitor_.hold_tags(node_id, type); }
+#ifdef TATUM_CALCULATE_EDGE_SLACKS
         TimingTags::tag_range hold_edge_slacks_impl(EdgeId edge_id) const override { return setup_hold_visitor_.hold_edge_slacks(edge_id); }
+#endif
         TimingTags::tag_range hold_node_slacks_impl(NodeId node_id) const override { return setup_hold_visitor_.hold_node_slacks(node_id); }
 
     private:

--- a/libtatum/tatum/analyzers/FullSetupTimingAnalyzer.hpp
+++ b/libtatum/tatum/analyzers/FullSetupTimingAnalyzer.hpp
@@ -61,6 +61,10 @@ class FullSetupTimingAnalyzer : public SetupTimingAnalyzer {
             graph_walker_.invalidate_edge(edge);
         }
 
+        virtual node_range modified_nodes_impl() const override {
+            return graph_walker_.modified_nodes();
+        }
+
         //TimingAnalyzer
         double get_profiling_data_impl(std::string key) const override { return graph_walker_.get_profiling_data(key); }
         size_t num_unconstrained_startpoints_impl() const override { return graph_walker_.num_unconstrained_startpoints(); }

--- a/libtatum/tatum/analyzers/FullSetupTimingAnalyzer.hpp
+++ b/libtatum/tatum/analyzers/FullSetupTimingAnalyzer.hpp
@@ -57,6 +57,10 @@ class FullSetupTimingAnalyzer : public SetupTimingAnalyzer {
             graph_walker_.set_profiling_data("num_full_updates", graph_walker_.get_profiling_data("num_full_updates") + 1);
         }
 
+        virtual void invalidate_edge_impl(const EdgeId edge) override {
+            graph_walker_.invalidate_edge(edge);
+        }
+
         //TimingAnalyzer
         double get_profiling_data_impl(std::string key) const override { return graph_walker_.get_profiling_data(key); }
         size_t num_unconstrained_startpoints_impl() const override { return graph_walker_.num_unconstrained_startpoints(); }

--- a/libtatum/tatum/analyzers/FullSetupTimingAnalyzer.hpp
+++ b/libtatum/tatum/analyzers/FullSetupTimingAnalyzer.hpp
@@ -73,7 +73,9 @@ class FullSetupTimingAnalyzer : public SetupTimingAnalyzer {
         //SetupTimingAnalyzer
         TimingTags::tag_range setup_tags_impl(NodeId node_id) const override { return setup_visitor_.setup_tags(node_id); }
         TimingTags::tag_range setup_tags_impl(NodeId node_id, TagType type) const override { return setup_visitor_.setup_tags(node_id, type); }
+#ifdef TATUM_CALCULATE_EDGE_SLACKS
         TimingTags::tag_range setup_edge_slacks_impl(EdgeId edge_id) const override { return setup_visitor_.setup_edge_slacks(edge_id); }
+#endif
         TimingTags::tag_range setup_node_slacks_impl(NodeId node_id) const override { return setup_visitor_.setup_node_slacks(node_id); }
 
 

--- a/libtatum/tatum/analyzers/HoldTimingAnalyzer.hpp
+++ b/libtatum/tatum/analyzers/HoldTimingAnalyzer.hpp
@@ -19,14 +19,18 @@ class HoldTimingAnalyzer : public virtual TimingAnalyzer {
 
         TimingTags::tag_range hold_tags(NodeId node_id) const { return hold_tags_impl(node_id); }
         TimingTags::tag_range hold_tags(NodeId node_id, TagType type) const { return hold_tags_impl(node_id, type); }
+#ifdef TATUM_CALCULATE_EDGE_SLACKS
         TimingTags::tag_range hold_slacks(EdgeId edge_id) const { return hold_edge_slacks_impl(edge_id); }
+#endif
         TimingTags::tag_range hold_slacks(NodeId node_id) const { return hold_node_slacks_impl(node_id); }
 
     protected:
         virtual void update_hold_timing_impl() = 0;
         virtual TimingTags::tag_range hold_tags_impl(NodeId node_id) const = 0;
         virtual TimingTags::tag_range hold_tags_impl(NodeId node_id, TagType type) const = 0;
+#ifdef TATUM_CALCULATE_EDGE_SLACKS
         virtual TimingTags::tag_range hold_edge_slacks_impl(EdgeId edge_id) const = 0;
+#endif
         virtual TimingTags::tag_range hold_node_slacks_impl(NodeId node_id) const = 0;
 };
 

--- a/libtatum/tatum/analyzers/IncrHoldTimingAnalyzer.hpp
+++ b/libtatum/tatum/analyzers/IncrHoldTimingAnalyzer.hpp
@@ -1,0 +1,102 @@
+#pragma once
+#include "tatum/graph_walkers/SerialWalker.hpp"
+#include "tatum/HoldAnalysis.hpp"
+#include "tatum/analyzers/HoldTimingAnalyzer.hpp"
+#include "tatum/base/validate_timing_graph_constraints.hpp"
+
+namespace tatum { namespace detail {
+
+/**
+ * A concrete implementation of a HoldTimingAnalyzer.
+ *
+ * This is a full (i.e. non-incremental) analyzer, which fully
+ * re-analyzes the timing graph whenever update_timing_impl() is 
+ * called.
+ */
+template<class GraphWalker=SerialIncrWalker>
+class IncrHoldTimingAnalyzer : public HoldTimingAnalyzer {
+    public:
+        IncrHoldTimingAnalyzer(const TimingGraph& timing_graph, const TimingConstraints& timing_constraints, const DelayCalculator& delay_calculator)
+            : HoldTimingAnalyzer()
+            , timing_graph_(timing_graph)
+            , timing_constraints_(timing_constraints)
+            , delay_calculator_(delay_calculator)
+            , hold_visitor_(timing_graph_.nodes().size(), timing_graph_.edges().size()) {
+            validate_timing_graph_constraints(timing_graph_, timing_constraints_);
+
+            //Initialize profiling data
+            graph_walker_.set_profiling_data("total_analysis_sec", 0.);
+            graph_walker_.set_profiling_data("analysis_sec", 0.);
+            graph_walker_.set_profiling_data("num_full_updates", 0.);
+            graph_walker_.set_profiling_data("num_incr_updates", 0.);
+        }
+
+    protected:
+        virtual void update_timing_impl() override {
+            update_hold_timing_impl();
+        }
+
+        virtual void update_hold_timing_impl() override {
+            auto start_time = Clock::now();
+
+            if (never_updated_) {
+                //Invalidate all edges
+                for (EdgeId edge : timing_graph_.edges()) {
+                    graph_walker_.invalidate_edge(edge);
+                }
+
+                //Only need to pre-traverse the first update
+                graph_walker_.do_arrival_pre_traversal(timing_graph_, timing_constraints_, hold_visitor_);            
+            }
+
+            graph_walker_.do_arrival_traversal(timing_graph_, timing_constraints_, delay_calculator_, hold_visitor_);            
+
+            if (never_updated_) {
+                //Only need to pre-traverse the first update
+                graph_walker_.do_required_pre_traversal(timing_graph_, timing_constraints_, hold_visitor_);            
+            }
+
+            graph_walker_.do_required_traversal(timing_graph_, timing_constraints_, delay_calculator_, hold_visitor_);            
+
+            graph_walker_.do_update_slack(timing_graph_, delay_calculator_, hold_visitor_);
+
+            double analysis_sec = std::chrono::duration_cast<dsec>(Clock::now() - start_time).count();
+
+            graph_walker_.clear_invalidated_edges();
+
+            //Record profiling data
+            double total_analysis_sec = analysis_sec + graph_walker_.get_profiling_data("total_analysis_sec");
+            graph_walker_.set_profiling_data("total_analysis_sec", total_analysis_sec);
+            graph_walker_.set_profiling_data("analysis_sec", analysis_sec);
+            graph_walker_.set_profiling_data("num_incr_updates", graph_walker_.get_profiling_data("num_incr_updates") + 1);
+
+            never_updated_ = false;
+        }
+
+        virtual void invalidate_edge_impl(const EdgeId edge) override {
+            graph_walker_.invalidate_edge(edge);
+        }
+
+        double get_profiling_data_impl(std::string key) const override { return graph_walker_.get_profiling_data(key); }
+        size_t num_unconstrained_startpoints_impl() const override { return graph_walker_.num_unconstrained_startpoints(); }
+        size_t num_unconstrained_endpoints_impl() const override { return graph_walker_.num_unconstrained_endpoints(); }
+
+        TimingTags::tag_range hold_tags_impl(NodeId node_id) const override { return hold_visitor_.hold_tags(node_id); }
+        TimingTags::tag_range hold_tags_impl(NodeId node_id, TagType type) const override { return hold_visitor_.hold_tags(node_id, type); }
+        TimingTags::tag_range hold_edge_slacks_impl(EdgeId edge_id) const override { return hold_visitor_.hold_edge_slacks(edge_id); }
+        TimingTags::tag_range hold_node_slacks_impl(NodeId node_id) const override { return hold_visitor_.hold_node_slacks(node_id); }
+
+    private:
+        const TimingGraph& timing_graph_;
+        const TimingConstraints& timing_constraints_;
+        const DelayCalculator& delay_calculator_;
+        HoldAnalysis hold_visitor_;
+        GraphWalker graph_walker_;
+
+        bool never_updated_ = true;
+
+        typedef std::chrono::duration<double> dsec;
+        typedef std::chrono::high_resolution_clock Clock;
+};
+
+}} //namepsace

--- a/libtatum/tatum/analyzers/IncrHoldTimingAnalyzer.hpp
+++ b/libtatum/tatum/analyzers/IncrHoldTimingAnalyzer.hpp
@@ -87,7 +87,9 @@ class IncrHoldTimingAnalyzer : public HoldTimingAnalyzer {
 
         TimingTags::tag_range hold_tags_impl(NodeId node_id) const override { return hold_visitor_.hold_tags(node_id); }
         TimingTags::tag_range hold_tags_impl(NodeId node_id, TagType type) const override { return hold_visitor_.hold_tags(node_id, type); }
+#ifdef TATUM_CALCULATE_EDGE_SLACKS
         TimingTags::tag_range hold_edge_slacks_impl(EdgeId edge_id) const override { return hold_visitor_.hold_edge_slacks(edge_id); }
+#endif
         TimingTags::tag_range hold_node_slacks_impl(NodeId node_id) const override { return hold_visitor_.hold_node_slacks(node_id); }
 
     private:

--- a/libtatum/tatum/analyzers/IncrHoldTimingAnalyzer.hpp
+++ b/libtatum/tatum/analyzers/IncrHoldTimingAnalyzer.hpp
@@ -77,6 +77,10 @@ class IncrHoldTimingAnalyzer : public HoldTimingAnalyzer {
             graph_walker_.invalidate_edge(edge);
         }
 
+        virtual node_range modified_nodes_impl() const override {
+            return graph_walker_.modified_nodes();
+        }
+
         double get_profiling_data_impl(std::string key) const override { return graph_walker_.get_profiling_data(key); }
         size_t num_unconstrained_startpoints_impl() const override { return graph_walker_.num_unconstrained_startpoints(); }
         size_t num_unconstrained_endpoints_impl() const override { return graph_walker_.num_unconstrained_endpoints(); }

--- a/libtatum/tatum/analyzers/IncrHoldTimingAnalyzer.hpp
+++ b/libtatum/tatum/analyzers/IncrHoldTimingAnalyzer.hpp
@@ -9,9 +9,9 @@ namespace tatum { namespace detail {
 /**
  * A concrete implementation of a HoldTimingAnalyzer.
  *
- * This is a full (i.e. non-incremental) analyzer, which fully
- * re-analyzes the timing graph whenever update_timing_impl() is 
- * called.
+ * This is an incremental analyzer, which will incrementally
+ * update the timing graph based on edges which have been marked
+ * as invalidated.
  */
 template<class GraphWalker=SerialIncrWalker>
 class IncrHoldTimingAnalyzer : public HoldTimingAnalyzer {

--- a/libtatum/tatum/analyzers/IncrSetupHoldTimingAnalyzer.hpp
+++ b/libtatum/tatum/analyzers/IncrSetupHoldTimingAnalyzer.hpp
@@ -1,0 +1,125 @@
+#pragma once
+#include "tatum/graph_walkers/SerialWalker.hpp"
+#include "tatum/SetupHoldAnalysis.hpp"
+#include "tatum/analyzers/SetupHoldTimingAnalyzer.hpp"
+#include "tatum/base/validate_timing_graph_constraints.hpp"
+
+namespace tatum { namespace detail {
+
+/**
+ * A concrete implementation of a SetupHoldTimingAnalyzer.
+ *
+ * This is a full (i.e. non-incremental) analyzer, which fully
+ * re-analyzes the timing graph whenever update_timing_impl() is 
+ * called.
+ */
+template<class GraphWalker=SerialWalker>
+class IncrSetupHoldTimingAnalyzer : public SetupHoldTimingAnalyzer {
+    public:
+        IncrSetupHoldTimingAnalyzer(const TimingGraph& timing_graph, const TimingConstraints& timing_constraints, const DelayCalculator& delay_calculator)
+            : SetupHoldTimingAnalyzer()
+            , timing_graph_(timing_graph)
+            , timing_constraints_(timing_constraints)
+            , delay_calculator_(delay_calculator)
+            , setup_hold_visitor_(timing_graph_.nodes().size(), timing_graph_.edges().size()) {
+            validate_timing_graph_constraints(timing_graph_, timing_constraints_);
+
+            //Initialize profiling data
+            graph_walker_.set_profiling_data("total_analysis_sec", 0.);
+            graph_walker_.set_profiling_data("analysis_sec", 0.);
+            graph_walker_.set_profiling_data("num_full_updates", 0.);
+        }
+
+    protected:
+        //Update both setup and hold simultaneously (this is more efficient than updating them sequentially)
+        virtual void update_timing_impl() override {
+            auto start_time = Clock::now();
+
+            if (never_updated_) {
+                for (EdgeId edge : timing_graph_.edges()) {
+                    graph_walker_.invalidate_edge(edge);
+                }
+
+                graph_walker_.do_arrival_pre_traversal(timing_graph_, timing_constraints_, setup_hold_visitor_);            
+            }
+
+            graph_walker_.do_arrival_traversal(timing_graph_, timing_constraints_, delay_calculator_, setup_hold_visitor_);            
+
+            if (never_updated_) {
+                graph_walker_.do_required_pre_traversal(timing_graph_, timing_constraints_, setup_hold_visitor_);            
+            }
+
+            graph_walker_.do_required_traversal(timing_graph_, timing_constraints_, delay_calculator_, setup_hold_visitor_);            
+
+            graph_walker_.do_update_slack(timing_graph_, delay_calculator_, setup_hold_visitor_);
+
+            double analysis_sec = std::chrono::duration_cast<dsec>(Clock::now() - start_time).count();
+
+            never_updated_ = false;
+            graph_walker_.clear_invalidated_edges();
+
+            //Record profiling data
+            double total_analysis_sec = analysis_sec + graph_walker_.get_profiling_data("total_analysis_sec");
+            graph_walker_.set_profiling_data("total_analysis_sec", total_analysis_sec);
+            graph_walker_.set_profiling_data("analysis_sec", analysis_sec);
+            graph_walker_.set_profiling_data("num_full_updates", graph_walker_.get_profiling_data("num_full_updates") + 1);
+        }
+
+        //Update only setup timing
+        virtual void update_setup_timing_impl() override {
+            auto& setup_visitor = setup_hold_visitor_.setup_visitor();
+
+            graph_walker_.do_arrival_pre_traversal(timing_graph_, timing_constraints_, setup_visitor);            
+            graph_walker_.do_arrival_traversal(timing_graph_, timing_constraints_, delay_calculator_, setup_visitor);            
+
+            graph_walker_.do_required_pre_traversal(timing_graph_, timing_constraints_, setup_visitor);            
+            graph_walker_.do_required_traversal(timing_graph_, timing_constraints_, delay_calculator_, setup_visitor);            
+
+            graph_walker_.do_update_slack(timing_graph_, delay_calculator_, setup_visitor);
+        }
+
+        //Update only hold timing
+        virtual void update_hold_timing_impl() override {
+            auto& hold_visitor = setup_hold_visitor_.hold_visitor();
+
+            graph_walker_.do_arrival_pre_traversal(timing_graph_, timing_constraints_, hold_visitor);            
+            graph_walker_.do_arrival_traversal(timing_graph_, timing_constraints_, delay_calculator_, hold_visitor);            
+
+            graph_walker_.do_required_pre_traversal(timing_graph_, timing_constraints_, hold_visitor);            
+            graph_walker_.do_required_traversal(timing_graph_, timing_constraints_, delay_calculator_, hold_visitor);            
+
+            graph_walker_.do_update_slack(timing_graph_, delay_calculator_, hold_visitor);
+        }
+
+        virtual void invalidate_edge_impl(const EdgeId edge) override {
+            graph_walker_.invalidate_edge(edge);
+        }
+
+        double get_profiling_data_impl(std::string key) const override { return graph_walker_.get_profiling_data(key); }
+        size_t num_unconstrained_startpoints_impl() const override { return graph_walker_.num_unconstrained_startpoints(); }
+        size_t num_unconstrained_endpoints_impl() const override { return graph_walker_.num_unconstrained_endpoints(); }
+
+        TimingTags::tag_range setup_tags_impl(NodeId node_id) const override { return setup_hold_visitor_.setup_tags(node_id); }
+        TimingTags::tag_range setup_tags_impl(NodeId node_id, TagType type) const override { return setup_hold_visitor_.setup_tags(node_id, type); }
+        TimingTags::tag_range setup_edge_slacks_impl(EdgeId edge_id) const override { return setup_hold_visitor_.setup_edge_slacks(edge_id); }
+        TimingTags::tag_range setup_node_slacks_impl(NodeId node_id) const override { return setup_hold_visitor_.setup_node_slacks(node_id); }
+
+        TimingTags::tag_range hold_tags_impl(NodeId node_id) const override { return setup_hold_visitor_.hold_tags(node_id); }
+        TimingTags::tag_range hold_tags_impl(NodeId node_id, TagType type) const override { return setup_hold_visitor_.hold_tags(node_id, type); }
+        TimingTags::tag_range hold_edge_slacks_impl(EdgeId edge_id) const override { return setup_hold_visitor_.hold_edge_slacks(edge_id); }
+        TimingTags::tag_range hold_node_slacks_impl(NodeId node_id) const override { return setup_hold_visitor_.hold_node_slacks(node_id); }
+
+    private:
+        const TimingGraph& timing_graph_;
+        const TimingConstraints& timing_constraints_;
+        const DelayCalculator& delay_calculator_;
+        SetupHoldAnalysis setup_hold_visitor_;
+        GraphWalker graph_walker_;
+
+        bool never_updated_ = true;
+
+        typedef std::chrono::duration<double> dsec;
+        typedef std::chrono::high_resolution_clock Clock;
+};
+
+}} //namepsace

--- a/libtatum/tatum/analyzers/IncrSetupHoldTimingAnalyzer.hpp
+++ b/libtatum/tatum/analyzers/IncrSetupHoldTimingAnalyzer.hpp
@@ -102,6 +102,10 @@ class IncrSetupHoldTimingAnalyzer : public SetupHoldTimingAnalyzer {
             graph_walker_.invalidate_edge(edge);
         }
 
+        virtual node_range modified_nodes_impl() const override {
+            return graph_walker_.modified_nodes();
+        }
+
         double get_profiling_data_impl(std::string key) const override { return graph_walker_.get_profiling_data(key); }
         size_t num_unconstrained_startpoints_impl() const override { return graph_walker_.num_unconstrained_startpoints(); }
         size_t num_unconstrained_endpoints_impl() const override { return graph_walker_.num_unconstrained_endpoints(); }

--- a/libtatum/tatum/analyzers/IncrSetupHoldTimingAnalyzer.hpp
+++ b/libtatum/tatum/analyzers/IncrSetupHoldTimingAnalyzer.hpp
@@ -112,12 +112,16 @@ class IncrSetupHoldTimingAnalyzer : public SetupHoldTimingAnalyzer {
 
         TimingTags::tag_range setup_tags_impl(NodeId node_id) const override { return setup_hold_visitor_.setup_tags(node_id); }
         TimingTags::tag_range setup_tags_impl(NodeId node_id, TagType type) const override { return setup_hold_visitor_.setup_tags(node_id, type); }
+#ifdef TATUM_CALCULATE_EDGE_SLACKS
         TimingTags::tag_range setup_edge_slacks_impl(EdgeId edge_id) const override { return setup_hold_visitor_.setup_edge_slacks(edge_id); }
+#endif
         TimingTags::tag_range setup_node_slacks_impl(NodeId node_id) const override { return setup_hold_visitor_.setup_node_slacks(node_id); }
 
         TimingTags::tag_range hold_tags_impl(NodeId node_id) const override { return setup_hold_visitor_.hold_tags(node_id); }
         TimingTags::tag_range hold_tags_impl(NodeId node_id, TagType type) const override { return setup_hold_visitor_.hold_tags(node_id, type); }
+#ifdef TATUM_CALCULATE_EDGE_SLACKS
         TimingTags::tag_range hold_edge_slacks_impl(EdgeId edge_id) const override { return setup_hold_visitor_.hold_edge_slacks(edge_id); }
+#endif
         TimingTags::tag_range hold_node_slacks_impl(NodeId node_id) const override { return setup_hold_visitor_.hold_node_slacks(node_id); }
 
     private:

--- a/libtatum/tatum/analyzers/IncrSetupHoldTimingAnalyzer.hpp
+++ b/libtatum/tatum/analyzers/IncrSetupHoldTimingAnalyzer.hpp
@@ -9,9 +9,9 @@ namespace tatum { namespace detail {
 /**
  * A concrete implementation of a SetupHoldTimingAnalyzer.
  *
- * This is a full (i.e. non-incremental) analyzer, which fully
- * re-analyzes the timing graph whenever update_timing_impl() is 
- * called.
+ * This is an incremental analyzer, which will incrementally
+ * update the timing graph based on edges which have been marked
+ * as invalidated.
  */
 template<class GraphWalker=SerialIncrWalker>
 class IncrSetupHoldTimingAnalyzer : public SetupHoldTimingAnalyzer {

--- a/libtatum/tatum/analyzers/IncrSetupTimingAnalyzer.hpp
+++ b/libtatum/tatum/analyzers/IncrSetupTimingAnalyzer.hpp
@@ -9,9 +9,9 @@ namespace tatum { namespace detail {
 /**
  * A concrete implementation of a SetupTimingAnalyzer.
  *
- * This is a full (i.e. non-incremental) analyzer, which fully
- * re-analyzes the timing graph whenever update_timing_impl() is 
- * called.
+ * This is an incremental analyzer, which will incrementally
+ * update the timing graph based on edges which have been marked
+ * as invalidated.
  */
 template<class GraphWalker=SerialIncrWalker>
 class IncrSetupTimingAnalyzer : public SetupTimingAnalyzer {

--- a/libtatum/tatum/analyzers/IncrSetupTimingAnalyzer.hpp
+++ b/libtatum/tatum/analyzers/IncrSetupTimingAnalyzer.hpp
@@ -77,6 +77,10 @@ class IncrSetupTimingAnalyzer : public SetupTimingAnalyzer {
             graph_walker_.invalidate_edge(edge);
         }
 
+        virtual node_range modified_nodes_impl() const override {
+            return graph_walker_.modified_nodes();
+        }
+
         double get_profiling_data_impl(std::string key) const override { return graph_walker_.get_profiling_data(key); }
         size_t num_unconstrained_startpoints_impl() const override { return graph_walker_.num_unconstrained_startpoints(); }
         size_t num_unconstrained_endpoints_impl() const override { return graph_walker_.num_unconstrained_endpoints(); }

--- a/libtatum/tatum/analyzers/IncrSetupTimingAnalyzer.hpp
+++ b/libtatum/tatum/analyzers/IncrSetupTimingAnalyzer.hpp
@@ -87,7 +87,9 @@ class IncrSetupTimingAnalyzer : public SetupTimingAnalyzer {
 
         TimingTags::tag_range setup_tags_impl(NodeId node_id) const override { return setup_visitor_.setup_tags(node_id); }
         TimingTags::tag_range setup_tags_impl(NodeId node_id, TagType type) const override { return setup_visitor_.setup_tags(node_id, type); }
+#ifdef TATUM_CALCULATE_EDGE_SLACKS
         TimingTags::tag_range setup_edge_slacks_impl(EdgeId edge_id) const override { return setup_visitor_.setup_edge_slacks(edge_id); }
+#endif
         TimingTags::tag_range setup_node_slacks_impl(NodeId node_id) const override { return setup_visitor_.setup_node_slacks(node_id); }
     private:
         const TimingGraph& timing_graph_;

--- a/libtatum/tatum/analyzers/IncrSetupTimingAnalyzer.hpp
+++ b/libtatum/tatum/analyzers/IncrSetupTimingAnalyzer.hpp
@@ -1,0 +1,101 @@
+#pragma once
+#include "tatum/graph_walkers/SerialWalker.hpp"
+#include "tatum/SetupAnalysis.hpp"
+#include "tatum/analyzers/SetupTimingAnalyzer.hpp"
+#include "tatum/base/validate_timing_graph_constraints.hpp"
+
+namespace tatum { namespace detail {
+
+/**
+ * A concrete implementation of a SetupTimingAnalyzer.
+ *
+ * This is a full (i.e. non-incremental) analyzer, which fully
+ * re-analyzes the timing graph whenever update_timing_impl() is 
+ * called.
+ */
+template<class GraphWalker=SerialIncrWalker>
+class IncrSetupTimingAnalyzer : public SetupTimingAnalyzer {
+    public:
+        IncrSetupTimingAnalyzer(const TimingGraph& timing_graph, const TimingConstraints& timing_constraints, const DelayCalculator& delay_calculator)
+            : SetupTimingAnalyzer()
+            , timing_graph_(timing_graph)
+            , timing_constraints_(timing_constraints)
+            , delay_calculator_(delay_calculator)
+            , setup_visitor_(timing_graph_.nodes().size(), timing_graph_.edges().size()) {
+            validate_timing_graph_constraints(timing_graph_, timing_constraints_);
+
+            //Initialize profiling data
+            graph_walker_.set_profiling_data("total_analysis_sec", 0.);
+            graph_walker_.set_profiling_data("analysis_sec", 0.);
+            graph_walker_.set_profiling_data("num_full_updates", 0.);
+            graph_walker_.set_profiling_data("num_incr_updates", 0.);
+        }
+
+    protected:
+        //Update both setup and hold simultaneously (this is more efficient than updating them sequentially)
+        virtual void update_timing_impl() override {
+            update_setup_timing_impl();
+        }
+        virtual void update_setup_timing_impl() override {
+            auto start_time = Clock::now();
+
+            if (never_updated_) {
+                //Invalidate all edges
+                for (EdgeId edge : timing_graph_.edges()) {
+                    graph_walker_.invalidate_edge(edge);
+                }
+
+                //Only need to pre-traverse the first update
+                graph_walker_.do_arrival_pre_traversal(timing_graph_, timing_constraints_, setup_visitor_);            
+            }
+
+            graph_walker_.do_arrival_traversal(timing_graph_, timing_constraints_, delay_calculator_, setup_visitor_);            
+
+            if (never_updated_) {
+                //Only need to pre-traverse the first update
+                graph_walker_.do_required_pre_traversal(timing_graph_, timing_constraints_, setup_visitor_);            
+            }
+
+            graph_walker_.do_required_traversal(timing_graph_, timing_constraints_, delay_calculator_, setup_visitor_);            
+
+            graph_walker_.do_update_slack(timing_graph_, delay_calculator_, setup_visitor_);
+
+            double analysis_sec = std::chrono::duration_cast<dsec>(Clock::now() - start_time).count();
+
+            graph_walker_.clear_invalidated_edges();
+
+            //Record profiling data
+            double total_analysis_sec = analysis_sec + graph_walker_.get_profiling_data("total_analysis_sec");
+            graph_walker_.set_profiling_data("total_analysis_sec", total_analysis_sec);
+            graph_walker_.set_profiling_data("analysis_sec", analysis_sec);
+            graph_walker_.set_profiling_data("num_incr_updates", graph_walker_.get_profiling_data("num_incr_updates") + 1);
+
+            never_updated_ = false;
+        }
+
+        virtual void invalidate_edge_impl(const EdgeId edge) override {
+            graph_walker_.invalidate_edge(edge);
+        }
+
+        double get_profiling_data_impl(std::string key) const override { return graph_walker_.get_profiling_data(key); }
+        size_t num_unconstrained_startpoints_impl() const override { return graph_walker_.num_unconstrained_startpoints(); }
+        size_t num_unconstrained_endpoints_impl() const override { return graph_walker_.num_unconstrained_endpoints(); }
+
+        TimingTags::tag_range setup_tags_impl(NodeId node_id) const override { return setup_visitor_.setup_tags(node_id); }
+        TimingTags::tag_range setup_tags_impl(NodeId node_id, TagType type) const override { return setup_visitor_.setup_tags(node_id, type); }
+        TimingTags::tag_range setup_edge_slacks_impl(EdgeId edge_id) const override { return setup_visitor_.setup_edge_slacks(edge_id); }
+        TimingTags::tag_range setup_node_slacks_impl(NodeId node_id) const override { return setup_visitor_.setup_node_slacks(node_id); }
+    private:
+        const TimingGraph& timing_graph_;
+        const TimingConstraints& timing_constraints_;
+        const DelayCalculator& delay_calculator_;
+        SetupAnalysis setup_visitor_;
+        GraphWalker graph_walker_;
+
+        bool never_updated_ = true;
+
+        typedef std::chrono::duration<double> dsec;
+        typedef std::chrono::high_resolution_clock Clock;
+};
+
+}} //namepsace

--- a/libtatum/tatum/analyzers/SetupTimingAnalyzer.hpp
+++ b/libtatum/tatum/analyzers/SetupTimingAnalyzer.hpp
@@ -19,14 +19,18 @@ class SetupTimingAnalyzer : public virtual TimingAnalyzer {
 
         TimingTags::tag_range setup_tags(NodeId node_id) const { return setup_tags_impl(node_id); }
         TimingTags::tag_range setup_tags(NodeId node_id, TagType type) const { return setup_tags_impl(node_id, type); }
+#ifdef TATUM_CALCULATE_EDGE_SLACKS
         TimingTags::tag_range setup_slacks(EdgeId edge_id) const { return setup_edge_slacks_impl(edge_id); }
+#endif
         TimingTags::tag_range setup_slacks(NodeId node_id) const { return setup_node_slacks_impl(node_id); }
 
     protected:
         virtual void update_setup_timing_impl() = 0;
         virtual TimingTags::tag_range setup_tags_impl(NodeId node_id) const = 0;
         virtual TimingTags::tag_range setup_tags_impl(NodeId node_id, TagType type) const = 0;
+#ifdef TATUM_CALCULATE_EDGE_SLACKS
         virtual TimingTags::tag_range setup_edge_slacks_impl(EdgeId edge_id) const = 0;
+#endif
         virtual TimingTags::tag_range setup_node_slacks_impl(NodeId node_id) const = 0;
 };
 

--- a/libtatum/tatum/analyzers/TimingAnalyzer.hpp
+++ b/libtatum/tatum/analyzers/TimingAnalyzer.hpp
@@ -1,6 +1,8 @@
 #pragma once
 #include <string>
 
+#include "tatum/TimingGraphFwd.hpp"
+
 namespace tatum {
 
 /**
@@ -28,12 +30,17 @@ class TimingAnalyzer {
         ///Perform timing analysis to update timing information (i.e. arrival & required times)
         void update_timing() { update_timing_impl(); }
 
+        ///Invalidates the specified edge in the timing graph (for incremental updates)
+        void invalidate_edge(const EdgeId edge) { invalidate_edge_impl(edge); }
+
         double get_profiling_data(std::string key) const { return get_profiling_data_impl(key); }
 
         virtual size_t num_unconstrained_startpoints() const { return num_unconstrained_startpoints_impl(); }
         virtual size_t num_unconstrained_endpoints() const { return num_unconstrained_endpoints_impl(); }
 
     protected:
+        virtual void invalidate_edge_impl(const EdgeId edge) = 0;
+
         virtual void update_timing_impl() = 0;
 
         virtual double get_profiling_data_impl(std::string key) const = 0;

--- a/libtatum/tatum/analyzers/TimingAnalyzer.hpp
+++ b/libtatum/tatum/analyzers/TimingAnalyzer.hpp
@@ -37,6 +37,7 @@ class TimingAnalyzer {
         ///Invalidates the specified edge in the timing graph (for incremental updates)
         void invalidate_edge(const EdgeId edge) { invalidate_edge_impl(edge); }
 
+        ///Returns the set of nodes which were modified by the last call to update_timing()
         node_range modified_nodes() const { return modified_nodes_impl(); }
 
         double get_profiling_data(std::string key) const { return get_profiling_data_impl(key); }

--- a/libtatum/tatum/analyzers/TimingAnalyzer.hpp
+++ b/libtatum/tatum/analyzers/TimingAnalyzer.hpp
@@ -1,7 +1,9 @@
 #pragma once
 #include <string>
+#include <vector>
 
 #include "tatum/TimingGraphFwd.hpp"
+#include "tatum/util/tatum_range.hpp"
 
 namespace tatum {
 
@@ -25,6 +27,8 @@ namespace tatum {
  */
 class TimingAnalyzer {
     public:
+        typedef tatum::util::Range<std::vector<NodeId>::const_iterator> node_range;
+    public:
         virtual ~TimingAnalyzer() {}
 
         ///Perform timing analysis to update timing information (i.e. arrival & required times)
@@ -33,15 +37,19 @@ class TimingAnalyzer {
         ///Invalidates the specified edge in the timing graph (for incremental updates)
         void invalidate_edge(const EdgeId edge) { invalidate_edge_impl(edge); }
 
+        node_range modified_nodes() const { return modified_nodes_impl(); }
+
         double get_profiling_data(std::string key) const { return get_profiling_data_impl(key); }
 
         virtual size_t num_unconstrained_startpoints() const { return num_unconstrained_startpoints_impl(); }
         virtual size_t num_unconstrained_endpoints() const { return num_unconstrained_endpoints_impl(); }
 
     protected:
-        virtual void invalidate_edge_impl(const EdgeId edge) = 0;
 
         virtual void update_timing_impl() = 0;
+
+        virtual void invalidate_edge_impl(const EdgeId edge) = 0;
+        virtual node_range modified_nodes_impl() const = 0;
 
         virtual double get_profiling_data_impl(std::string key) const = 0;
 

--- a/libtatum/tatum/analyzers/full_timing_analyzers.hpp
+++ b/libtatum/tatum/analyzers/full_timing_analyzers.hpp
@@ -5,8 +5,6 @@
  *
  * In particular these concrete analyzers are 'full' (i.e. non-incremental) timing analyzers,
  * ever call to update_timing_impl() fully re-analyze the timing graph.
- *
- * Note that at this time only 'full' analyzers are supported.
  */
 
 #include "FullSetupTimingAnalyzer.hpp"

--- a/libtatum/tatum/analyzers/incr_timing_analyzers.hpp
+++ b/libtatum/tatum/analyzers/incr_timing_analyzers.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+/** \file
+ * This file defines concrete implementations of the TimingAnalyzer interfaces.
+ *
+ * In particular these concrete analyzers are 'incr' (i.e. incremental) timing analyzers,
+ * ever call to update_timing_impl() incrementally re-analyze the timing graph.
+ */
+
+//#include "IncrSetupTimingAnalyzer.hpp"
+//#include "IncrHoldTimingAnalyzer.hpp"
+#include "IncrSetupHoldTimingAnalyzer.hpp"

--- a/libtatum/tatum/analyzers/incr_timing_analyzers.hpp
+++ b/libtatum/tatum/analyzers/incr_timing_analyzers.hpp
@@ -7,6 +7,6 @@
  * ever call to update_timing_impl() incrementally re-analyze the timing graph.
  */
 
-//#include "IncrSetupTimingAnalyzer.hpp"
-//#include "IncrHoldTimingAnalyzer.hpp"
+#include "IncrSetupTimingAnalyzer.hpp"
+#include "IncrHoldTimingAnalyzer.hpp"
 #include "IncrSetupHoldTimingAnalyzer.hpp"

--- a/libtatum/tatum/delay_calc/FixedDelayCalculator.hpp
+++ b/libtatum/tatum/delay_calc/FixedDelayCalculator.hpp
@@ -49,6 +49,12 @@ class FixedDelayCalculator : public DelayCalculator {
         Time setup_time(const TimingGraph& /*tg*/, EdgeId edge_id) const override { return setup_times_[edge_id]; }
 
         Time hold_time(const TimingGraph& /*tg*/, EdgeId edge_id) const override { return hold_times_[edge_id]; }
+
+        //Mutators
+        void set_max_edge_delay(const TimingGraph& /*tg*/, EdgeId edge_id, Time delay) { max_edge_delays_[edge_id] = delay; } 
+        void set_min_edge_delay(const TimingGraph& /*tg*/, EdgeId edge_id, Time delay) { min_edge_delays_[edge_id] = delay; } 
+        void set_setup_time(const TimingGraph& /*tg*/, EdgeId edge_id, Time delay) { setup_times_[edge_id] = delay; } 
+        void set_hold_time(const TimingGraph& /*tg*/, EdgeId edge_id, Time delay) { hold_times_[edge_id] = delay; } 
  
     private:
         tatum::util::linear_map<EdgeId,Time> max_edge_delays_;

--- a/libtatum/tatum/echo_writer.cpp
+++ b/libtatum/tatum/echo_writer.cpp
@@ -248,10 +248,12 @@ void write_analysis_result(std::ostream& os, const TimingGraph& tg, const std::s
             NodeId node_id(node_idx);
             write_tags(os, "SETUP_CAPTURE_CLOCK", setup_analyzer->setup_tags(node_id, TagType::CLOCK_CAPTURE), node_id);
         }
+#ifdef TATUM_CALCULATE_EDGE_SLACKS
         for(size_t edge_idx = 0; edge_idx < tg.edges().size(); ++edge_idx) {
             EdgeId edge_id(edge_idx);
             write_slacks(os, "SETUP_SLACK", setup_analyzer->setup_slacks(edge_id), edge_id);
         }
+#endif
         for(size_t node_idx = 0; node_idx < tg.nodes().size(); ++node_idx) {
             NodeId node_id(node_idx);
             write_slacks(os, "SETUP_SLACK", setup_analyzer->setup_slacks(node_id), node_id);
@@ -275,10 +277,12 @@ void write_analysis_result(std::ostream& os, const TimingGraph& tg, const std::s
             NodeId node_id(node_idx);
             write_tags(os, "HOLD_CAPTURE_CLOCK", hold_analyzer->hold_tags(node_id, TagType::CLOCK_CAPTURE), node_id);
         }
+#ifdef TATUM_CALCULATE_EDGE_SLACKS
         for(size_t edge_idx = 0; edge_idx < tg.edges().size(); ++edge_idx) {
             EdgeId edge_id(edge_idx);
             write_slacks(os, "HOLD_SLACK", hold_analyzer->hold_slacks(edge_id), edge_id);
         }
+#endif
         for(size_t node_idx = 0; node_idx < tg.nodes().size(); ++node_idx) {
             NodeId node_id(node_idx);
             write_slacks(os, "HOLD_SLACK", hold_analyzer->hold_slacks(node_id), node_id);

--- a/libtatum/tatum/graph_visitors/CommonAnalysisOps.hpp
+++ b/libtatum/tatum/graph_visitors/CommonAnalysisOps.hpp
@@ -41,8 +41,8 @@ class CommonAnalysisOps {
             return node_tags_[node_id].tags(type); 
         }
 
-        void add_tag(const NodeId node, const TimingTag& tag) {
-            node_tags_[node].add_tag(tag);
+        bool add_tag(const NodeId node, const TimingTag& tag) {
+            return node_tags_[node].add_tag(tag);
         }
 
         void reset_node(const NodeId node) { 
@@ -50,14 +50,14 @@ class CommonAnalysisOps {
             node_slacks_[node].clear();
         }
 
-        void merge_slack_tags(const EdgeId edge, const Time time, TimingTag ref_tag) { 
+        bool merge_slack_tags(const EdgeId edge, const Time time, TimingTag ref_tag) { 
             ref_tag.set_type(TagType::SLACK);
-            edge_slacks_[edge].min(time, ref_tag.origin_node(), ref_tag); 
+            return edge_slacks_[edge].min(time, ref_tag.origin_node(), ref_tag); 
         }
 
-        void merge_slack_tags(const NodeId node, const Time time, TimingTag ref_tag) { 
+        bool merge_slack_tags(const NodeId node, const Time time, TimingTag ref_tag) { 
             ref_tag.set_type(TagType::SLACK);
-            node_slacks_[node].min(time, ref_tag.origin_node(), ref_tag); 
+            return node_slacks_[node].min(time, ref_tag.origin_node(), ref_tag); 
         }
 
         TimingTags::tag_range get_edge_slacks(const EdgeId edge) const {

--- a/libtatum/tatum/graph_visitors/CommonAnalysisOps.hpp
+++ b/libtatum/tatum/graph_visitors/CommonAnalysisOps.hpp
@@ -19,8 +19,13 @@ class CommonAnalysisOps {
     public:
         CommonAnalysisOps(size_t num_nodes, size_t num_edges) 
             : node_tags_(num_nodes)
+#ifdef TATUM_CALCULATE_EDGE_SLACKS
             , edge_slacks_(num_edges)
-            , node_slacks_(num_nodes) {}
+#else
+#endif
+            , node_slacks_(num_nodes) {
+            static_cast<void>(num_edges); //Avoid unused param warning
+        }
 
         CommonAnalysisOps(const CommonAnalysisOps&) = delete;
         CommonAnalysisOps(CommonAnalysisOps&&) = delete;
@@ -55,27 +60,29 @@ class CommonAnalysisOps {
             node_slacks_[node].clear();
         }
 
-        bool merge_slack_tags(const EdgeId edge, const Time time, TimingTag ref_tag) { 
-            ref_tag.set_type(TagType::SLACK);
-            return edge_slacks_[edge].min(time, ref_tag.origin_node(), ref_tag); 
-        }
-
         bool merge_slack_tags(const NodeId node, const Time time, TimingTag ref_tag) { 
             ref_tag.set_type(TagType::SLACK);
             return node_slacks_[node].min(time, ref_tag.origin_node(), ref_tag); 
-        }
-
-        TimingTags::tag_range get_edge_slacks(const EdgeId edge) const {
-            return edge_slacks_[edge].tags(TagType::SLACK);
         }
 
         TimingTags::tag_range get_node_slacks(const NodeId node) const {
             return node_slacks_[node].tags(TagType::SLACK);
         }
 
+#ifdef TATUM_CALCULATE_EDGE_SLACKS
+        bool merge_slack_tags(const EdgeId edge, const Time time, TimingTag ref_tag) { 
+            ref_tag.set_type(TagType::SLACK);
+            return edge_slacks_[edge].min(time, ref_tag.origin_node(), ref_tag); 
+        }
+
+        TimingTags::tag_range get_edge_slacks(const EdgeId edge) const {
+            return edge_slacks_[edge].tags(TagType::SLACK);
+        }
+
         void reset_edge(const EdgeId edge) { 
             edge_slacks_[edge].clear();
         }
+#endif
 
         Time invalid_slack_time() const {
             return Time(std::numeric_limits<float>::infinity());
@@ -85,7 +92,10 @@ class CommonAnalysisOps {
     protected:
         tatum::util::linear_map<NodeId,TimingTags> node_tags_;
 
+#ifdef TATUM_CALCULATE_EDGE_SLACKS
         tatum::util::linear_map<EdgeId,TimingTags> edge_slacks_;
+#endif
+
         tatum::util::linear_map<NodeId,TimingTags> node_slacks_;
 };
 

--- a/libtatum/tatum/graph_visitors/CommonAnalysisOps.hpp
+++ b/libtatum/tatum/graph_visitors/CommonAnalysisOps.hpp
@@ -41,10 +41,6 @@ class CommonAnalysisOps {
             return node_tags_[node_id].tags(type); 
         }
 
-        bool add_tag(const NodeId node, const TimingTag& tag) {
-            return node_tags_[node].add_tag(tag);
-        }
-
         bool set_tag(const NodeId node, const TimingTag& tag) {
             return node_tags_[node].set_tag(tag);
         }

--- a/libtatum/tatum/graph_visitors/CommonAnalysisOps.hpp
+++ b/libtatum/tatum/graph_visitors/CommonAnalysisOps.hpp
@@ -27,11 +27,11 @@ class CommonAnalysisOps {
         CommonAnalysisOps& operator=(const CommonAnalysisOps&) = delete;
         CommonAnalysisOps& operator=(CommonAnalysisOps&&) = delete;
 
-        TimingTags::tag_range get_tags(const NodeId node_id) { 
-            return node_tags_[node_id].tags(); 
+        TimingTags::mutable_tag_range get_mutable_tags(const NodeId node_id) { 
+            return node_tags_[node_id].mutable_tags(); 
         }
-        TimingTags::tag_range get_tags(const NodeId node_id, TagType type) { 
-            return node_tags_[node_id].tags(type); 
+        TimingTags::mutable_tag_range get_mutable_tags(const NodeId node_id, TagType type) { 
+            return node_tags_[node_id].mutable_tags(type); 
         }
 
         TimingTags::tag_range get_tags(const NodeId node_id) const { 

--- a/libtatum/tatum/graph_visitors/CommonAnalysisOps.hpp
+++ b/libtatum/tatum/graph_visitors/CommonAnalysisOps.hpp
@@ -30,8 +30,13 @@ class CommonAnalysisOps {
         TimingTags::mutable_tag_range get_mutable_tags(const NodeId node_id) { 
             return node_tags_[node_id].mutable_tags(); 
         }
+
         TimingTags::mutable_tag_range get_mutable_tags(const NodeId node_id, TagType type) { 
             return node_tags_[node_id].mutable_tags(type); 
+        }
+
+        TimingTags::mutable_tag_range get_mutable_slack_tags(const NodeId node_id) { 
+            return node_slacks_[node_id].mutable_tags(); 
         }
 
         TimingTags::tag_range get_tags(const NodeId node_id) const { 
@@ -70,6 +75,10 @@ class CommonAnalysisOps {
 
         void reset_edge(const EdgeId edge) { 
             edge_slacks_[edge].clear();
+        }
+
+        Time invalid_slack_time() const {
+            return Time(std::numeric_limits<float>::infinity());
         }
 
 

--- a/libtatum/tatum/graph_visitors/CommonAnalysisOps.hpp
+++ b/libtatum/tatum/graph_visitors/CommonAnalysisOps.hpp
@@ -45,6 +45,10 @@ class CommonAnalysisOps {
             return node_tags_[node].add_tag(tag);
         }
 
+        bool set_tag(const NodeId node, const TimingTag& tag) {
+            return node_tags_[node].set_tag(tag);
+        }
+
         void reset_node(const NodeId node) { 
             node_tags_[node].clear();
             node_slacks_[node].clear();

--- a/libtatum/tatum/graph_visitors/CommonAnalysisVisitor.hpp
+++ b/libtatum/tatum/graph_visitors/CommonAnalysisVisitor.hpp
@@ -161,7 +161,8 @@ bool CommonAnalysisVisitor<AnalysisOps>::do_arrival_pre_traverse_node(const Timi
         } else {
             //A standard primary input, generate the appropriate data tags
 
-            TATUM_ASSERT_MSG(ops_.get_tags(node_id, TagType::DATA_ARRIVAL).size() == 0, "Primary input already has data tags");
+            //No longer true for an incremental analyzer
+            //TATUM_ASSERT_MSG(ops_.get_tags(node_id, TagType::DATA_ARRIVAL).size() == 0, "Primary input already has data tags");
 
             auto input_constraints = ops_.input_constraints(tc, node_id);
             if(!input_constraints.empty()) { //Some inputs may be unconstrained, so do not create tags for them

--- a/libtatum/tatum/graph_visitors/CommonAnalysisVisitor.hpp
+++ b/libtatum/tatum/graph_visitors/CommonAnalysisVisitor.hpp
@@ -34,6 +34,9 @@ class CommonAnalysisVisitor : public GraphVisitor {
         void do_reset_node(const NodeId node_id) override { ops_.reset_node(node_id); }
         void do_reset_edge(const EdgeId edge_id) override { ops_.reset_edge(edge_id); }
 
+        void do_reset_node_arrival_tags(const NodeId node_id) override;
+        void do_reset_node_required_tags(const NodeId node_id) override;
+
         bool do_arrival_pre_traverse_node(const TimingGraph& tg, const TimingConstraints& tc, const NodeId node_id) override;
 
         bool do_required_pre_traverse_node(const TimingGraph& tg, const TimingConstraints& tc, const NodeId node_id) override;
@@ -69,6 +72,26 @@ class CommonAnalysisVisitor : public GraphVisitor {
 /*
  * Pre-traversal
  */
+
+template<class AnalysisOps>
+void CommonAnalysisVisitor<AnalysisOps>::do_reset_node_arrival_tags(const NodeId node_id) {
+    for (TagType type : {TagType::CLOCK_LAUNCH, TagType::CLOCK_CAPTURE, TagType::DATA_ARRIVAL}) {
+        for (TimingTag& tag : ops_.get_mutable_tags(node_id, type)) {
+            tag.set_origin_node(NodeId::INVALID());        
+            tag.set_time(ops_.invalid_arrival_time());
+        }
+    }
+}
+
+template<class AnalysisOps>
+void CommonAnalysisVisitor<AnalysisOps>::do_reset_node_required_tags(const NodeId node_id) {
+    for (TagType type : {TagType::DATA_REQUIRED}) {
+        for (TimingTag& tag : ops_.get_mutable_tags(node_id, type)) {
+            tag.set_origin_node(NodeId::INVALID());        
+            tag.set_time(ops_.invalid_required_time());
+        }
+    }
+}
 
 template<class AnalysisOps>
 bool CommonAnalysisVisitor<AnalysisOps>::do_arrival_pre_traverse_node(const TimingGraph& tg, const TimingConstraints& tc, const NodeId node_id) {

--- a/libtatum/tatum/graph_visitors/CommonAnalysisVisitor.hpp
+++ b/libtatum/tatum/graph_visitors/CommonAnalysisVisitor.hpp
@@ -186,7 +186,7 @@ bool CommonAnalysisVisitor<AnalysisOps>::do_arrival_pre_traverse_node(const Timi
                                                 NodeId::INVALID(), //Origin
                                                 TagType::DATA_ARRIVAL);
 
-                ops_.add_tag(node_id, input_tag);
+                ops_.merge_arr_tags(node_id, input_tag);
 
                 node_constrained = true;
             }
@@ -504,7 +504,7 @@ bool CommonAnalysisVisitor<AnalysisOps>::mark_sink_required_times(const TimingGr
                                                 NodeId::INVALID(), //Origin
                                                 TagType::DATA_REQUIRED);
 
-                    timing_modified |= ops_.merge_req_tags(node_id, req_time, NodeId::INVALID(), node_data_req_tag);
+                    timing_modified |= ops_.merge_req_tags(node_id, node_data_req_tag);
                 }
             }
         }
@@ -565,7 +565,7 @@ bool CommonAnalysisVisitor<AnalysisOps>::mark_sink_required_times(const TimingGr
                                                     NodeId::INVALID(), //Origin
                                                     TagType::DATA_REQUIRED);
 
-                        timing_modified |= ops_.merge_req_tags(node_id, req_time, NodeId::INVALID(), node_data_req_tag);
+                        timing_modified |= ops_.merge_req_tags(node_id, node_data_req_tag);
                     }
                 }
             }

--- a/libtatum/tatum/graph_visitors/CommonAnalysisVisitor.hpp
+++ b/libtatum/tatum/graph_visitors/CommonAnalysisVisitor.hpp
@@ -37,6 +37,9 @@ class CommonAnalysisVisitor : public GraphVisitor {
         void do_reset_node_arrival_tags(const NodeId node_id) override;
         void do_reset_node_required_tags(const NodeId node_id) override;
 
+        void do_reset_node_arrival_tags_from_origin(const NodeId node_id, const NodeId origin) override;
+        void do_reset_node_required_tags_from_origin(const NodeId node_id, const NodeId origin) override;
+
         bool do_arrival_pre_traverse_node(const TimingGraph& tg, const TimingConstraints& tc, const NodeId node_id) override;
 
         bool do_required_pre_traverse_node(const TimingGraph& tg, const TimingConstraints& tc, const NodeId node_id) override;
@@ -89,6 +92,31 @@ void CommonAnalysisVisitor<AnalysisOps>::do_reset_node_required_tags(const NodeI
         for (TimingTag& tag : ops_.get_mutable_tags(node_id, type)) {
             tag.set_origin_node(NodeId::INVALID());        
             tag.set_time(ops_.invalid_required_time());
+        }
+    }
+}
+
+
+template<class AnalysisOps>
+void CommonAnalysisVisitor<AnalysisOps>::do_reset_node_arrival_tags_from_origin(const NodeId node_id, const NodeId origin) {
+    for (TagType type : {TagType::CLOCK_LAUNCH, TagType::CLOCK_CAPTURE, TagType::DATA_ARRIVAL}) {
+        for (TimingTag& tag : ops_.get_mutable_tags(node_id, type)) {
+            if (tag.origin_node() == origin) {
+                tag.set_origin_node(NodeId::INVALID());        
+                tag.set_time(ops_.invalid_arrival_time());
+            }
+        }
+    }
+}
+
+template<class AnalysisOps>
+void CommonAnalysisVisitor<AnalysisOps>::do_reset_node_required_tags_from_origin(const NodeId node_id, const NodeId origin) {
+    for (TagType type : {TagType::DATA_REQUIRED}) {
+        for (TimingTag& tag : ops_.get_mutable_tags(node_id, type)) {
+            if (tag.origin_node() == origin) {
+                tag.set_origin_node(NodeId::INVALID());        
+                tag.set_time(ops_.invalid_required_time());
+            }
         }
     }
 }

--- a/libtatum/tatum/graph_visitors/CommonAnalysisVisitor.hpp
+++ b/libtatum/tatum/graph_visitors/CommonAnalysisVisitor.hpp
@@ -97,7 +97,7 @@ bool CommonAnalysisVisitor<AnalysisOps>::do_arrival_pre_traverse_node(const Timi
         //by any non-constant tag at downstream nodes
 
         TimingTag const_gen_tag = ops_.const_gen_tag();
-        ops_.add_tag(node_id, const_gen_tag);
+        ops_.set_tag(node_id, const_gen_tag);
 
         node_constrained = true;
     } else {
@@ -106,9 +106,6 @@ bool CommonAnalysisVisitor<AnalysisOps>::do_arrival_pre_traverse_node(const Timi
 
         if(tc.node_is_clock_source(node_id)) {
             //Generate the appropriate clock tag
-
-            TATUM_ASSERT_MSG(ops_.get_tags(node_id, TagType::CLOCK_LAUNCH).size() == 0, "Uninitialized clock source should have no launch clock tags");
-            TATUM_ASSERT_MSG(ops_.get_tags(node_id, TagType::CLOCK_CAPTURE).size() == 0, "Uninitialized clock source should have no capture clock tags");
 
             //Find the domain of this node (since it is a source)
             DomainId domain_id = tc.node_clock_domain(node_id);
@@ -126,7 +123,7 @@ bool CommonAnalysisVisitor<AnalysisOps>::do_arrival_pre_traverse_node(const Timi
                                              NodeId::INVALID(), //Origin
                                              TagType::CLOCK_LAUNCH);
             //Add the launch tag
-            ops_.add_tag(node_id, launch_tag);
+            ops_.set_tag(node_id, launch_tag);
 
             //Initialize the clock capture tags from any valid launch domain to this domain
             //
@@ -153,7 +150,7 @@ bool CommonAnalysisVisitor<AnalysisOps>::do_arrival_pre_traverse_node(const Timi
                                                       NodeId::INVALID(), //Origin
                                                       TagType::CLOCK_CAPTURE);
 
-                    ops_.add_tag(node_id, capture_tag);
+                    ops_.set_tag(node_id, capture_tag);
 
                     node_constrained = true;
                 }

--- a/libtatum/tatum/graph_visitors/CommonAnalysisVisitor.hpp
+++ b/libtatum/tatum/graph_visitors/CommonAnalysisVisitor.hpp
@@ -36,6 +36,7 @@ class CommonAnalysisVisitor : public GraphVisitor {
 
         void do_reset_node_arrival_tags(const NodeId node_id) override;
         void do_reset_node_required_tags(const NodeId node_id) override;
+        void do_reset_node_slack_tags(const NodeId node_id) override;
 
         void do_reset_node_arrival_tags_from_origin(const NodeId node_id, const NodeId origin) override;
         void do_reset_node_required_tags_from_origin(const NodeId node_id, const NodeId origin) override;
@@ -93,6 +94,14 @@ void CommonAnalysisVisitor<AnalysisOps>::do_reset_node_required_tags(const NodeI
             tag.set_origin_node(NodeId::INVALID());        
             tag.set_time(ops_.invalid_required_time());
         }
+    }
+}
+
+template<class AnalysisOps>
+void CommonAnalysisVisitor<AnalysisOps>::do_reset_node_slack_tags(const NodeId node_id) {
+    for (TimingTag& tag : ops_.get_mutable_slack_tags(node_id)) {
+        tag.set_origin_node(NodeId::INVALID());        
+        tag.set_time(ops_.invalid_slack_time());
     }
 }
 

--- a/libtatum/tatum/graph_visitors/CommonAnalysisVisitor.hpp
+++ b/libtatum/tatum/graph_visitors/CommonAnalysisVisitor.hpp
@@ -32,7 +32,9 @@ class CommonAnalysisVisitor : public GraphVisitor {
             : ops_(num_tags, num_slacks) { }
 
         void do_reset_node(const NodeId node_id) override { ops_.reset_node(node_id); }
+#ifdef TATUM_CALCULATE_EDGE_SLACKS
         void do_reset_edge(const EdgeId edge_id) override { ops_.reset_edge(edge_id); }
+#endif
 
         void do_reset_node_arrival_tags(const NodeId node_id) override;
         void do_reset_node_required_tags(const NodeId node_id) override;
@@ -443,9 +445,15 @@ bool CommonAnalysisVisitor<AnalysisOps>::do_slack_traverse_node(const TimingGrap
     bool timing_modified = false;
 
     //Calculate the slack for each edge
+#ifdef TATUM_CALCULATE_EDGE_SLACKS
     for(const EdgeId edge : tg.node_in_edges(node)) {
         timing_modified |= do_slack_traverse_edge(tg, dc, edge);
     }
+#else
+    //Avoid unused param warnings
+    static_cast<void>(dc);
+    static_cast<void>(tg);
+#endif
 
     //Calculate the slacks at each node
     for(const TimingTag& arr_tag : ops_.get_tags(node, TagType::DATA_ARRIVAL)) {

--- a/libtatum/tatum/graph_visitors/CommonAnalysisVisitor.hpp
+++ b/libtatum/tatum/graph_visitors/CommonAnalysisVisitor.hpp
@@ -504,7 +504,7 @@ bool CommonAnalysisVisitor<AnalysisOps>::mark_sink_required_times(const TimingGr
                                                 NodeId::INVALID(), //Origin
                                                 TagType::DATA_REQUIRED);
 
-                    timing_modified |= ops_.add_tag(node_id, node_data_req_tag);
+                    timing_modified |= ops_.merge_req_tags(node_id, req_time, NodeId::INVALID(), node_data_req_tag);
                 }
             }
         }
@@ -565,7 +565,7 @@ bool CommonAnalysisVisitor<AnalysisOps>::mark_sink_required_times(const TimingGr
                                                     NodeId::INVALID(), //Origin
                                                     TagType::DATA_REQUIRED);
 
-                        timing_modified |= ops_.add_tag(node_id, node_data_req_tag);
+                        timing_modified |= ops_.merge_req_tags(node_id, req_time, NodeId::INVALID(), node_data_req_tag);
                     }
                 }
             }

--- a/libtatum/tatum/graph_visitors/GraphVisitor.hpp
+++ b/libtatum/tatum/graph_visitors/GraphVisitor.hpp
@@ -9,7 +9,10 @@ class GraphVisitor {
     public:
         virtual ~GraphVisitor() {}
         virtual void do_reset_node(const NodeId node_id) = 0;
+
+#ifdef TATUM_CALCULATE_EDGE_SLACKS
         virtual void do_reset_edge(const EdgeId edge_id) = 0;
+#endif
 
         virtual void do_reset_node_arrival_tags(const NodeId node_id) = 0;
         virtual void do_reset_node_required_tags(const NodeId node_id) = 0;

--- a/libtatum/tatum/graph_visitors/GraphVisitor.hpp
+++ b/libtatum/tatum/graph_visitors/GraphVisitor.hpp
@@ -11,6 +11,9 @@ class GraphVisitor {
         virtual void do_reset_node(const NodeId node_id) = 0;
         virtual void do_reset_edge(const EdgeId edge_id) = 0;
 
+        virtual void do_reset_node_arrival_tags(const NodeId node_id) = 0;
+        virtual void do_reset_node_required_tags(const NodeId node_id) = 0;
+
         //Returns true if the specified source/sink is unconstrainted
         virtual bool do_arrival_pre_traverse_node(const TimingGraph& tg, const TimingConstraints& tc, const NodeId node_id) = 0;
         virtual bool do_required_pre_traverse_node(const TimingGraph& tg, const TimingConstraints& tc, const NodeId node_id) = 0;

--- a/libtatum/tatum/graph_visitors/GraphVisitor.hpp
+++ b/libtatum/tatum/graph_visitors/GraphVisitor.hpp
@@ -11,13 +11,15 @@ class GraphVisitor {
         virtual void do_reset_node(const NodeId node_id) = 0;
         virtual void do_reset_edge(const EdgeId edge_id) = 0;
 
+        //Returns true if the specified source/sink is unconstrainted
         virtual bool do_arrival_pre_traverse_node(const TimingGraph& tg, const TimingConstraints& tc, const NodeId node_id) = 0;
         virtual bool do_required_pre_traverse_node(const TimingGraph& tg, const TimingConstraints& tc, const NodeId node_id) = 0;
 
-        virtual void do_arrival_traverse_node(const TimingGraph& tg, const TimingConstraints& tc, const DelayCalculator& dc, const NodeId node_id) = 0;
-        virtual void do_required_traverse_node(const TimingGraph& tg, const TimingConstraints& tc, const DelayCalculator& dc, const NodeId node_id) = 0;
+        //Returns true if the specified node was updated
+        virtual bool do_arrival_traverse_node(const TimingGraph& tg, const TimingConstraints& tc, const DelayCalculator& dc, const NodeId node_id) = 0;
+        virtual bool do_required_traverse_node(const TimingGraph& tg, const TimingConstraints& tc, const DelayCalculator& dc, const NodeId node_id) = 0;
 
-        virtual void do_slack_traverse_node(const TimingGraph& tg, const DelayCalculator& dc, const NodeId node) = 0;
+        virtual bool do_slack_traverse_node(const TimingGraph& tg, const DelayCalculator& dc, const NodeId node) = 0;
 };
 
 }

--- a/libtatum/tatum/graph_visitors/GraphVisitor.hpp
+++ b/libtatum/tatum/graph_visitors/GraphVisitor.hpp
@@ -13,6 +13,7 @@ class GraphVisitor {
 
         virtual void do_reset_node_arrival_tags(const NodeId node_id) = 0;
         virtual void do_reset_node_required_tags(const NodeId node_id) = 0;
+        virtual void do_reset_node_slack_tags(const NodeId node_id) = 0;
 
         virtual void do_reset_node_arrival_tags_from_origin(const NodeId node_id, const NodeId origin) = 0;
         virtual void do_reset_node_required_tags_from_origin(const NodeId node_id, const NodeId origin) = 0;

--- a/libtatum/tatum/graph_visitors/GraphVisitor.hpp
+++ b/libtatum/tatum/graph_visitors/GraphVisitor.hpp
@@ -14,6 +14,9 @@ class GraphVisitor {
         virtual void do_reset_node_arrival_tags(const NodeId node_id) = 0;
         virtual void do_reset_node_required_tags(const NodeId node_id) = 0;
 
+        virtual void do_reset_node_arrival_tags_from_origin(const NodeId node_id, const NodeId origin) = 0;
+        virtual void do_reset_node_required_tags_from_origin(const NodeId node_id, const NodeId origin) = 0;
+
         //Returns true if the specified source/sink is unconstrainted
         virtual bool do_arrival_pre_traverse_node(const TimingGraph& tg, const TimingConstraints& tc, const NodeId node_id) = 0;
         virtual bool do_required_pre_traverse_node(const TimingGraph& tg, const TimingConstraints& tc, const NodeId node_id) = 0;

--- a/libtatum/tatum/graph_visitors/HoldAnalysisOps.hpp
+++ b/libtatum/tatum/graph_visitors/HoldAnalysisOps.hpp
@@ -109,6 +109,14 @@ class HoldAnalysisOps : public CommonAnalysisOps {
             }
         }
 
+        Time invalid_arrival_time() {
+            return Time(std::numeric_limits<float>::infinity());
+        }
+
+        Time invalid_required_time() {
+            return Time(-std::numeric_limits<float>::infinity());
+        }
+
         Time calculate_slack(const Time required_time, const Time arrival_time) {
             //Hold requires the arrival to occur *after* the required time, so
             //slack is the amount of arrival time left after the required time; meaning

--- a/libtatum/tatum/graph_visitors/HoldAnalysisOps.hpp
+++ b/libtatum/tatum/graph_visitors/HoldAnalysisOps.hpp
@@ -60,12 +60,12 @@ class HoldAnalysisOps : public CommonAnalysisOps {
 
         TimingTag const_gen_tag() { return TimingTag::CONST_GEN_TAG_HOLD(); }
 
-        void merge_req_tags(const NodeId node, const Time time, const NodeId origin, const TimingTag& ref_tag, bool arrival_must_be_valid=false) { 
-            node_tags_[node].max(time, origin, ref_tag, arrival_must_be_valid); 
+        bool merge_req_tags(const NodeId node, const Time time, const NodeId origin, const TimingTag& ref_tag, bool arrival_must_be_valid=false) { 
+            return node_tags_[node].max(time, origin, ref_tag, arrival_must_be_valid); 
         }
 
-        void merge_arr_tags(const NodeId node, const Time time, const NodeId origin, const TimingTag& ref_tag) { 
-            node_tags_[node].min(time, origin, ref_tag); 
+        bool merge_arr_tags(const NodeId node, const Time time, const NodeId origin, const TimingTag& ref_tag) { 
+            return node_tags_[node].min(time, origin, ref_tag); 
         }
 
         Time data_edge_delay(const DelayCalculator& dc, const TimingGraph& tg, const EdgeId edge_id) { 

--- a/libtatum/tatum/graph_visitors/HoldAnalysisOps.hpp
+++ b/libtatum/tatum/graph_visitors/HoldAnalysisOps.hpp
@@ -60,8 +60,16 @@ class HoldAnalysisOps : public CommonAnalysisOps {
 
         TimingTag const_gen_tag() { return TimingTag::CONST_GEN_TAG_HOLD(); }
 
+        bool merge_req_tags(const NodeId node, const TimingTag& ref_tag, bool arrival_must_be_valid=false) { 
+            return merge_req_tags(node, ref_tag.time(), ref_tag.origin_node(), ref_tag, arrival_must_be_valid);
+        }
+
         bool merge_req_tags(const NodeId node, const Time time, const NodeId origin, const TimingTag& ref_tag, bool arrival_must_be_valid=false) { 
             return node_tags_[node].max(time, origin, ref_tag, arrival_must_be_valid); 
+        }
+
+        bool merge_arr_tags(const NodeId node, const TimingTag& ref_tag) { 
+            return merge_arr_tags(node, ref_tag.time(), ref_tag.origin_node(), ref_tag);
         }
 
         bool merge_arr_tags(const NodeId node, const Time time, const NodeId origin, const TimingTag& ref_tag) { 

--- a/libtatum/tatum/graph_visitors/SetupAnalysisOps.hpp
+++ b/libtatum/tatum/graph_visitors/SetupAnalysisOps.hpp
@@ -59,8 +59,16 @@ class SetupAnalysisOps : public CommonAnalysisOps {
 
         TimingTag const_gen_tag() { return TimingTag::CONST_GEN_TAG_SETUP(); }
 
+        bool merge_req_tags(const NodeId node, const TimingTag& ref_tag, bool arrival_must_be_valid=false) { 
+            return merge_req_tags(node, ref_tag.time(), ref_tag.origin_node(), ref_tag, arrival_must_be_valid);
+        }
+
         bool merge_req_tags(const NodeId node, const Time time, const NodeId origin, const TimingTag& ref_tag, bool arrival_must_be_valid=false) { 
             return node_tags_[node].min(time, origin, ref_tag, arrival_must_be_valid); 
+        }
+
+        bool merge_arr_tags(const NodeId node, const TimingTag& ref_tag) { 
+            return merge_arr_tags(node, ref_tag.time(), ref_tag.origin_node(), ref_tag);
         }
 
         bool merge_arr_tags(const NodeId node, const Time time, const NodeId origin, const TimingTag& ref_tag) { 

--- a/libtatum/tatum/graph_visitors/SetupAnalysisOps.hpp
+++ b/libtatum/tatum/graph_visitors/SetupAnalysisOps.hpp
@@ -110,6 +110,14 @@ class SetupAnalysisOps : public CommonAnalysisOps {
             }
         }
 
+        Time invalid_arrival_time() {
+            return Time(-std::numeric_limits<float>::infinity());
+        }
+
+        Time invalid_required_time() {
+            return Time(std::numeric_limits<float>::infinity());
+        }
+
         Time calculate_slack(const Time required_time, const Time arrival_time) {
             //Setup requires the arrival to occur *before* the required time, so
             //slack is the amount of required time left after the arrival time; meaning

--- a/libtatum/tatum/graph_visitors/SetupAnalysisOps.hpp
+++ b/libtatum/tatum/graph_visitors/SetupAnalysisOps.hpp
@@ -59,12 +59,12 @@ class SetupAnalysisOps : public CommonAnalysisOps {
 
         TimingTag const_gen_tag() { return TimingTag::CONST_GEN_TAG_SETUP(); }
 
-        void merge_req_tags(const NodeId node, const Time time, const NodeId origin, const TimingTag& ref_tag, bool arrival_must_be_valid=false) { 
-            node_tags_[node].min(time, origin, ref_tag, arrival_must_be_valid); 
+        bool merge_req_tags(const NodeId node, const Time time, const NodeId origin, const TimingTag& ref_tag, bool arrival_must_be_valid=false) { 
+            return node_tags_[node].min(time, origin, ref_tag, arrival_must_be_valid); 
         }
 
-        void merge_arr_tags(const NodeId node, const Time time, const NodeId origin, const TimingTag& ref_tag) { 
-            node_tags_[node].max(time, origin, ref_tag); 
+        bool merge_arr_tags(const NodeId node, const Time time, const NodeId origin, const TimingTag& ref_tag) { 
+            return node_tags_[node].max(time, origin, ref_tag); 
         }
 
         Time data_edge_delay(const DelayCalculator& dc, const TimingGraph& tg, const EdgeId edge_id) { 

--- a/libtatum/tatum/graph_walkers.hpp
+++ b/libtatum/tatum/graph_walkers.hpp
@@ -6,5 +6,6 @@
  */
 
 #include "graph_walkers/SerialWalker.hpp"
+#include "graph_walkers/SerialIncrWalker.hpp"
 #include "graph_walkers/ParallelLevelizedWalker.hpp"
 #include "graph_walkers/ParallelWalker.hpp"

--- a/libtatum/tatum/graph_walkers/ParallelLevelizedWalker.hpp
+++ b/libtatum/tatum/graph_walkers/ParallelLevelizedWalker.hpp
@@ -18,6 +18,10 @@ namespace tatum {
  */
 class ParallelLevelizedWalker : public TimingGraphWalker {
     public:
+        void invalidate_edge_impl(const EdgeId /*edge*/) override {
+            //Do nothing, this walker only does full updates
+        }
+
         void do_arrival_pre_traversal_impl(const TimingGraph& tg, const TimingConstraints& tc, GraphVisitor& visitor) override {
             num_unconstrained_startpoints_ = 0;
 

--- a/libtatum/tatum/graph_walkers/ParallelLevelizedWalker.hpp
+++ b/libtatum/tatum/graph_walkers/ParallelLevelizedWalker.hpp
@@ -140,21 +140,26 @@ class ParallelLevelizedWalker : public TimingGraphWalker {
 
         void do_reset_impl(const TimingGraph& tg, GraphVisitor& visitor) override {
             auto nodes = tg.nodes();
-            auto edges = tg.edges();
 #if defined(TATUM_USE_TBB)
             tbb::parallel_for_each(nodes.begin(), nodes.end(), [&](auto node) {
                 visitor.do_reset_node(node);
             });
+#   ifdef TATUM_CALCULATE_EDGE_SLACKS
+            auto edges = tg.edges();
             tbb::parallel_for_each(edges.begin(), edges.end(), [&](auto edge) {
                 visitor.do_reset_edge(edge);
             });
+#   endif
 #else //Serial
             for(auto node_iter = nodes.begin(); node_iter != nodes.end(); ++node_iter) {
                 visitor.do_reset_node(*node_iter);
             }
+#   ifdef TATUM_CALCULATE_EDGE_SLACKS
+            auto edges = tg.edges();
             for(auto edge_iter = edges.begin(); edge_iter != edges.end(); ++edge_iter) {
                 visitor.do_reset_edge(*edge_iter);
             }
+#   endif
 #endif
         }
 

--- a/libtatum/tatum/graph_walkers/ParallelLevelizedWalker.hpp
+++ b/libtatum/tatum/graph_walkers/ParallelLevelizedWalker.hpp
@@ -22,6 +22,10 @@ class ParallelLevelizedWalker : public TimingGraphWalker {
             //Do nothing, this walker only does full updates
         }
 
+        void clear_invalidated_edges_impl() override {
+            //Do nothing, this walker only does full updates
+        }
+
         void do_arrival_pre_traversal_impl(const TimingGraph& tg, const TimingConstraints& tc, GraphVisitor& visitor) override {
             num_unconstrained_startpoints_ = 0;
 

--- a/libtatum/tatum/graph_walkers/ParallelLevelizedWalker.hpp
+++ b/libtatum/tatum/graph_walkers/ParallelLevelizedWalker.hpp
@@ -26,7 +26,21 @@ class ParallelLevelizedWalker : public TimingGraphWalker {
             //Do nothing, this walker only does full updates
         }
 
+        node_range modified_nodes_impl() const override {
+            return tatum::util::make_range(nodes_modified_.cbegin(), nodes_modified_.cend());
+        }
+
+
         void do_arrival_pre_traversal_impl(const TimingGraph& tg, const TimingConstraints& tc, GraphVisitor& visitor) override {
+            if (nodes_modified_.empty()) {
+                //This is a non-incremental updater so all nodes are always updated
+                auto nodes = tg.nodes();
+                nodes_modified_.reserve(nodes.size());
+                for (NodeId node : nodes) {
+                    nodes_modified_.push_back(node);
+                }
+            }
+
             num_unconstrained_startpoints_ = 0;
 
             LevelId first_level = *tg.levels().begin();
@@ -160,6 +174,7 @@ class ParallelLevelizedWalker : public TimingGraphWalker {
 
         size_t num_unconstrained_startpoints_ = 0;
         size_t num_unconstrained_endpoints_ = 0;
+        std::vector<NodeId> nodes_modified_;
 };
 
 } //namepsace

--- a/libtatum/tatum/graph_walkers/SerialIncrWalker.hpp
+++ b/libtatum/tatum/graph_walkers/SerialIncrWalker.hpp
@@ -14,11 +14,19 @@ namespace tatum {
 class SerialIncrWalker : public TimingGraphWalker {
     protected:
         void invalidate_edge_impl(const EdgeId edge) override {
+            if (is_invalidated(edge)) return;
+
             invalidated_edges_.push_back(edge);
+
+            if (edge_invalidated_.size() <= size_t(edge)) {
+                edge_invalidated_.resize(size_t(edge)+1, false);
+            }
+            edge_invalidated_[edge] = true;
         }
 
         void clear_invalidated_edges_impl() override {
             invalidated_edges_.clear();
+            edge_invalidated_.clear();
         }
 
         node_range modified_nodes_impl() const override {
@@ -56,8 +64,7 @@ class SerialIncrWalker : public TimingGraphWalker {
 
         void do_arrival_traversal_impl(const TimingGraph& tg, const TimingConstraints& tc, const DelayCalculator& dc, GraphVisitor& visitor) override {
             nodes_modified_.clear();
-            resize_incr_update_levels(tg);
-            prepare_incr_arrival_update(tg, visitor);
+            prepare_incr_update(tg);
 
             //std::cout << "Arr Levels " << incr_arr_update_.min_level << ": " << incr_arr_update_.max_level << "\n";
             for(int level_idx = incr_arr_update_.min_level; level_idx <= incr_arr_update_.max_level; ++level_idx) {
@@ -72,6 +79,7 @@ class SerialIncrWalker : public TimingGraphWalker {
                 for (NodeId node : level_nodes) {
 
                     //std::cout << "  Processing Arr " << node << "\n";
+                    invalidate_node_for_arrival_traversal(node, tg, visitor);
 
                     bool node_updated = visitor.do_arrival_traverse_node(tg, tc, dc, node);
 
@@ -82,7 +90,7 @@ class SerialIncrWalker : public TimingGraphWalker {
                         //Queue this node's downstream dependencies for updating
                         for (EdgeId edge : tg.node_out_edges(node)) {
                             NodeId snk_node = tg.edge_sink_node(edge);
-                            enqueue_arr_node(tg, snk_node, edge, visitor);
+                            enqueue_arr_node(tg, snk_node, edge);
                         }
                     }
                 }
@@ -92,8 +100,6 @@ class SerialIncrWalker : public TimingGraphWalker {
         }
 
         void do_required_traversal_impl(const TimingGraph& tg, const TimingConstraints& tc, const DelayCalculator& dc, GraphVisitor& visitor) override {
-            resize_incr_update_levels(tg);
-            prepare_incr_required_update(tg, visitor);
 
             //std::cout << "Req Levels " << incr_req_update_.max_level << ": " << incr_req_update_.min_level << "\n";
             for(int level_idx = incr_req_update_.max_level; level_idx >= incr_req_update_.min_level; --level_idx) {
@@ -109,6 +115,7 @@ class SerialIncrWalker : public TimingGraphWalker {
 
                     //std::cout << "  Processing Req " << node << "\n";
 
+                    invalidate_node_for_required_traversal(node, tg, visitor);
                     bool node_updated = visitor.do_required_traverse_node(tg, tc, dc, node);
 
                     if (node_updated) {
@@ -122,7 +129,7 @@ class SerialIncrWalker : public TimingGraphWalker {
                         for (EdgeId edge : tg.node_in_edges(node)) {
                             NodeId src_node = tg.edge_src_node(edge);
 
-                            enqueue_req_node(tg, src_node, edge, visitor);
+                            enqueue_req_node(tg, src_node, edge);
                         }
                     }
                 }
@@ -166,13 +173,25 @@ class SerialIncrWalker : public TimingGraphWalker {
         size_t num_unconstrained_endpoints_impl() const override { return num_unconstrained_endpoints_; }
     private:
 
+        bool is_invalidated(EdgeId edge) const {
+            if (edge_invalidated_.size() > size_t(edge)) {
+                return edge_invalidated_[edge];
+            }
+            return false; //Not yet marked, so not invalid
+        }
+
+        bool not_invalidated(EdgeId edge) const {
+            return !is_invalidated(edge);
+        }
+
         void uniquify(std::vector<NodeId>& nodes) {
             std::sort(nodes.begin(), nodes.end());
             nodes.erase(std::unique(nodes.begin(), nodes.end()),
                         nodes.end());
         }
 
-        void prepare_incr_arrival_update(const TimingGraph& tg, GraphVisitor& visitor) {
+        void prepare_incr_update(const TimingGraph& tg) {
+            resize_incr_update_levels(tg);
             incr_arr_update_.min_level = size_t(*(tg.levels().end() - 1));
             incr_arr_update_.max_level = size_t(*tg.levels().begin());
             incr_req_update_.min_level = size_t(*(tg.levels().end() - 1));
@@ -180,9 +199,11 @@ class SerialIncrWalker : public TimingGraphWalker {
 
             //std::cout << "Invalidated Edges: " << invalidated_edges_.size() << " / " << tg.edges().size() << " (" << invalidated_edges_.size() / tg.edges().size() << ")\n";
             for (EdgeId edge : invalidated_edges_) {
-                NodeId node = tg.edge_sink_node(edge);
+                NodeId snk_node = tg.edge_sink_node(edge);
+                enqueue_arr_node(tg, snk_node, edge);
 
-                enqueue_arr_node(tg, node, edge, visitor);
+                NodeId src_node = tg.edge_src_node(edge);
+                enqueue_req_node(tg, src_node, edge);
             }
         }
 
@@ -194,13 +215,6 @@ class SerialIncrWalker : public TimingGraphWalker {
             incr_arr_update_.min_level = size_t(*(tg.levels().end() - 1));
             incr_arr_update_.max_level = size_t(*tg.levels().begin());
         }
-        void prepare_incr_required_update(const TimingGraph& tg, GraphVisitor& visitor) {
-            for (EdgeId edge : invalidated_edges_) {
-                NodeId node = tg.edge_src_node(edge);
-
-                enqueue_req_node(tg, node, edge, visitor);
-            }
-        }
 
         void complete_incr_required_update(const TimingGraph& tg) {
             for (int level = incr_req_update_.min_level; level <= incr_req_update_.max_level; ++level) {
@@ -211,75 +225,86 @@ class SerialIncrWalker : public TimingGraphWalker {
             incr_req_update_.max_level = size_t(*tg.levels().begin());
         }
 
-        void enqueue_arr_node(const TimingGraph& tg, NodeId node, EdgeId invalidated_edge, GraphVisitor& visitor) {
-            if (0) { //Block invalidation
-                visitor.do_reset_node_arrival_tags(node);
-            } else { //Edge invalidation
-                //Data arrival tags track their associated origin node (i.e. dominant
-                //edge which determines the tag value). Rather than invalidate all
-                //tags to ensure the correctly updated tag when the node is re-traversed,
-                //we can get away with only invalidating the tag when the dominant edge
-                //is invalidated.
-                //
-                //This ensures that cases where non-dominate edges change delay value,
-                //but not in ways which effect the tag value, we detect that the tag
-                //is 'unchanged', which helps keep the number of updated nodes small.
-                NodeId src_node = tg.edge_src_node(invalidated_edge);
-                visitor.do_reset_node_arrival_tags_from_origin(node, src_node);
-
-
-                //At SOURCE/SINK nodes clock launch/capture tags are converted into
-                //data arrival/required tags, so we also need to carefully reset those
-                //tags as well (since they don't track origin nodes this must be done
-                //seperately).
-                EdgeType edge_type = tg.edge_type(invalidated_edge);
-                if (edge_type == EdgeType::PRIMITIVE_CLOCK_CAPTURE) {
-                    //We mark required times on sinks based the clock capture time during
-                    //the arrival traversal.
-                    //
-                    //Therefore we need to invalidate the data required times (so they are
-                    //re-calculated correctly) when the clock caputre edge has been 
-                    //invalidated. Note that we don't need to enqueue the sink node for 
-                    //required time traversal, since the required time will be updated during
-                    //the arrival traversasl.
-                    visitor.do_reset_node_required_tags(node);
-
-                    //However, since the required time traversal doesn't update the sink node,
-                    //it's dependent nodes won't be enqueued for processing, even if the required
-                    //times changed, so we explicitly do that here
-                    for (EdgeId sink_in_edge : tg.node_in_edges(node)) {
-                        NodeId sink_src_node = tg.edge_src_node(sink_in_edge);
-                        enqueue_req_node(tg, sink_src_node, sink_in_edge, visitor);
-                    }
-                } else if (edge_type == EdgeType::PRIMITIVE_CLOCK_LAUNCH) {
-                    //On propagating to a SOURCE node, CLOCK_LAUNCH becomes DATA_ARRIVAL
-                    //we therefore invalidate any outstanding arrival tags if the clock launch
-                    //edge has been invalidated.
-                    //
-                    //This ensures the correct data arrivaltags are generated
-                    visitor.do_reset_node_arrival_tags(node);
-                }
-
-            }
-
+        void enqueue_arr_node(const TimingGraph& tg, NodeId node, EdgeId invalidated_edge) {
             //std::cout << "  Enqueing arr " << node << "\n";
+            invalidate_edge_impl(invalidated_edge);
             incr_arr_update_.enqueue_node(tg, node);
         }
 
-        void enqueue_req_node(const TimingGraph& tg, NodeId node, EdgeId invalidated_edge, GraphVisitor& visitor) {
-            if (0) { //Block invalidation
-                visitor.do_reset_node_required_tags(node);
-            } else { //Edge invalidation
-                NodeId snk_node = tg.edge_sink_node(invalidated_edge);
-                visitor.do_reset_node_required_tags_from_origin(node, snk_node);
-            }
-
+        void enqueue_req_node(const TimingGraph& tg, NodeId node, EdgeId invalidated_edge) {
             //std::cout << "  Enqueing req " << node << "\n";
+            invalidate_edge_impl(invalidated_edge);
             incr_req_update_.enqueue_node(tg, node);
         }
 
         void enqueue_slack_node(const NodeId node) {
             nodes_modified_.push_back(node); 
+        }
+
+        void invalidate_node_for_arrival_traversal(const NodeId node, const TimingGraph& tg, GraphVisitor& visitor) {
+            if (0) { //Block invalidation
+                visitor.do_reset_node_arrival_tags(node);
+            } else { //Edge invalidation
+                for (EdgeId edge : tg.node_in_edges(node)) {
+                    if (not_invalidated(edge)) continue;
+                    //Data arrival tags track their associated origin node (i.e. dominant
+                    //edge which determines the tag value). Rather than invalidate all
+                    //tags to ensure the correctly updated tag when the node is re-traversed,
+                    //we can get away with only invalidating the tag when the dominant edge
+                    //is invalidated.
+                    //
+                    //This ensures that cases where non-dominate edges change delay value,
+                    //but not in ways which effect the tag value, we detect that the tag
+                    //is 'unchanged', which helps keep the number of updated nodes small.
+                    NodeId src_node = tg.edge_src_node(edge);
+                    visitor.do_reset_node_arrival_tags_from_origin(node, /*origin=*/src_node);
+
+                    //At SOURCE/SINK nodes clock launch/capture tags are converted into
+                    //data arrival/required tags, so we also need to carefully reset those
+                    //tags as well (since they don't track origin nodes this must be done
+                    //seperately).
+                    EdgeType edge_type = tg.edge_type(edge);
+                    if (edge_type == EdgeType::PRIMITIVE_CLOCK_CAPTURE) {
+                        //We mark required times on sinks based the clock capture time during
+                        //the arrival traversal.
+                        //
+                        //Therefore we need to invalidate the data required times (so they are
+                        //re-calculated correctly) when the clock caputre edge has been 
+                        //invalidated. Note that we don't need to enqueue the sink node for 
+                        //required time traversal, since the required time will be updated during
+                        //the arrival traversasl.
+                        visitor.do_reset_node_required_tags(node);
+
+                        //However, since the required time traversal doesn't update the sink node,
+                        //it's dependent nodes won't be enqueued for processing, even if the required
+                        //times changed, so we explicitly do that here
+                        for (EdgeId sink_in_edge : tg.node_in_edges(node)) {
+                            NodeId sink_src_node = tg.edge_src_node(sink_in_edge);
+                            enqueue_req_node(tg, sink_src_node, sink_in_edge);
+                        }
+                    } else if (edge_type == EdgeType::PRIMITIVE_CLOCK_LAUNCH) {
+                        //On propagating to a SOURCE node, CLOCK_LAUNCH becomes DATA_ARRIVAL
+                        //we therefore invalidate any outstanding arrival tags if the clock launch
+                        //edge has been invalidated.
+                        //
+                        //This ensures the correct data arrivaltags are generated
+                        visitor.do_reset_node_arrival_tags(node);
+                    }
+                }
+            }
+        }
+
+        void invalidate_node_for_required_traversal(const NodeId node, const TimingGraph& tg, GraphVisitor& visitor) {
+            if (0) { //Block invalidation
+                visitor.do_reset_node_required_tags(node);
+            } else { //Edge invalidation
+                for (EdgeId edge : tg.node_out_edges(node)) {
+                    if (not_invalidated(edge)) continue;
+
+                    NodeId snk_node = tg.edge_sink_node(edge);
+                    visitor.do_reset_node_required_tags_from_origin(node, /*origin=*/snk_node);
+                }
+            }
         }
 
         void resize_incr_update_levels(const TimingGraph& tg) {
@@ -317,6 +342,7 @@ class SerialIncrWalker : public TimingGraphWalker {
         t_incr_traversal_update incr_req_update_;
 
         std::vector<EdgeId> invalidated_edges_;
+        tatum::util::linear_map<EdgeId,bool> edge_invalidated_;
         std::vector<NodeId> nodes_modified_; //Nodes which have been modified during timing update
 
         size_t num_unconstrained_startpoints_ = 0;

--- a/libtatum/tatum/graph_walkers/SerialIncrWalker.hpp
+++ b/libtatum/tatum/graph_walkers/SerialIncrWalker.hpp
@@ -140,9 +140,11 @@ class SerialIncrWalker : public TimingGraphWalker {
             for(NodeId node : nodes_modified_) {
                 //std::cout << "  Processing slack " << node << "\n";
 
+#ifdef TATUM_CALCULATE_EDGE_SLACKS
                 for (EdgeId edge : tg.node_in_edges(node)) {
                     visitor.do_reset_edge(edge);
                 }
+#endif
                 visitor.do_reset_node_slack_tags(node);
 
                 visitor.do_slack_traverse_node(tg, dc, node);
@@ -153,9 +155,11 @@ class SerialIncrWalker : public TimingGraphWalker {
             for(NodeId node_id : tg.nodes()) {
                 visitor.do_reset_node(node_id);
             }
+#ifdef TATUM_CALCULATE_EDGE_SLACKS
             for(EdgeId edge_id : tg.edges()) {
                 visitor.do_reset_edge(edge_id);
             }
+#endif
         }
 
         size_t num_unconstrained_startpoints_impl() const override { return num_unconstrained_startpoints_; }

--- a/libtatum/tatum/graph_walkers/SerialIncrWalker.hpp
+++ b/libtatum/tatum/graph_walkers/SerialIncrWalker.hpp
@@ -77,7 +77,7 @@ class SerialIncrWalker : public TimingGraphWalker {
                         for (EdgeId edge : tg.node_out_edges(node)) {
                             NodeId snk_node = tg.edge_sink_node(edge);
 
-                            enqueue_arr_node(tg, snk_node, visitor);
+                            enqueue_arr_node(tg, snk_node, edge, visitor);
                         }
                     }
                 }
@@ -113,7 +113,7 @@ class SerialIncrWalker : public TimingGraphWalker {
                         for (EdgeId edge : tg.node_in_edges(node)) {
                             NodeId src_node = tg.edge_src_node(edge);
 
-                            enqueue_req_node(tg, src_node, visitor);
+                            enqueue_req_node(tg, src_node, edge, visitor);
                         }
                     }
                 }
@@ -174,7 +174,7 @@ class SerialIncrWalker : public TimingGraphWalker {
             for (EdgeId edge : invalidated_edges_) {
                 NodeId node = tg.edge_sink_node(edge);
 
-                enqueue_arr_node(tg, node, visitor);
+                enqueue_arr_node(tg, node, edge, visitor);
             }
         }
 
@@ -198,18 +198,28 @@ class SerialIncrWalker : public TimingGraphWalker {
             for (EdgeId edge : invalidated_edges_) {
                 NodeId node = tg.edge_src_node(edge);
 
-                enqueue_req_node(tg, node, visitor);
+                enqueue_req_node(tg, node, edge, visitor);
             }
         }
 
-        void enqueue_arr_node(const TimingGraph& tg, NodeId node, GraphVisitor& visitor) {
-            visitor.do_reset_node_arrival_tags(node);
+        void enqueue_arr_node(const TimingGraph& tg, NodeId node, EdgeId invalidated_edge, GraphVisitor& visitor) {
+            if (0) { //Block invalidation
+                visitor.do_reset_node_arrival_tags(node);
+            } else { //Edge invalidation
+                NodeId src_node = tg.edge_src_node(invalidated_edge);
+                visitor.do_reset_node_arrival_tags_from_origin(node, src_node);
+            }
 
             incr_arr_update_.enqueue_node(tg, node);
         }
 
-        void enqueue_req_node(const TimingGraph& tg, NodeId node, GraphVisitor& visitor) {
-            visitor.do_reset_node_required_tags(node);
+        void enqueue_req_node(const TimingGraph& tg, NodeId node, EdgeId invalidated_edge, GraphVisitor& visitor) {
+            if (0) { //Block invalidation
+                visitor.do_reset_node_required_tags(node);
+            } else { //Edge invalidation
+                NodeId snk_node = tg.edge_sink_node(invalidated_edge);
+                visitor.do_reset_node_required_tags_from_origin(node, snk_node);
+            }
 
             incr_req_update_.enqueue_node(tg, node);
         }

--- a/libtatum/tatum/graph_walkers/SerialIncrWalker.hpp
+++ b/libtatum/tatum/graph_walkers/SerialIncrWalker.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <algorithm>
 #include "tatum/graph_walkers/TimingGraphWalker.hpp"
 #include "tatum/TimingGraph.hpp"
 #include "tatum/delay_calc/DelayCalculator.hpp"

--- a/libtatum/tatum/graph_walkers/SerialIncrWalker.hpp
+++ b/libtatum/tatum/graph_walkers/SerialIncrWalker.hpp
@@ -1,0 +1,82 @@
+#pragma once
+#include "tatum/graph_walkers/TimingGraphWalker.hpp"
+#include "tatum/TimingGraph.hpp"
+#include "tatum/delay_calc/DelayCalculator.hpp"
+#include "tatum/graph_visitors/GraphVisitor.hpp"
+
+namespace tatum {
+
+/**
+ * A simple serial graph walker which traverses the timing graph in a levelized
+ * manner.
+ */
+class SerialIncrWalker : public TimingGraphWalker {
+    protected:
+        void do_arrival_pre_traversal_impl(const TimingGraph& tg, const TimingConstraints& tc, GraphVisitor& visitor) override {
+            size_t num_unconstrained = 0;
+
+            LevelId first_level = *tg.levels().begin();
+            for(NodeId node_id : tg.level_nodes(first_level)) {
+                bool constrained = visitor.do_arrival_pre_traverse_node(tg, tc, node_id);
+
+                if(!constrained) {
+                    ++num_unconstrained;
+                }
+            }
+
+            num_unconstrained_startpoints_ = num_unconstrained;
+        }
+
+        void do_required_pre_traversal_impl(const TimingGraph& tg, const TimingConstraints& tc, GraphVisitor& visitor) override {
+            size_t num_unconstrained = 0;
+
+            for(NodeId node_id : tg.logical_outputs()) {
+                bool constrained = visitor.do_required_pre_traverse_node(tg, tc, node_id);
+
+                if(!constrained) {
+                    ++num_unconstrained;
+                }
+            }
+
+            num_unconstrained_endpoints_ = num_unconstrained;
+        }
+
+        void do_arrival_traversal_impl(const TimingGraph& tg, const TimingConstraints& tc, const DelayCalculator& dc, GraphVisitor& visitor) override {
+            for(LevelId level_id : tg.levels()) {
+                for(NodeId node_id : tg.level_nodes(level_id)) {
+                    visitor.do_arrival_traverse_node(tg, tc, dc, node_id);
+                }
+            }
+        }
+
+        void do_required_traversal_impl(const TimingGraph& tg, const TimingConstraints& tc, const DelayCalculator& dc, GraphVisitor& visitor) override {
+            for(LevelId level_id : tg.reversed_levels()) {
+                for(NodeId node_id : tg.level_nodes(level_id)) {
+                    visitor.do_required_traverse_node(tg, tc, dc, node_id);
+                }
+            }
+        }
+
+        void do_update_slack_impl(const TimingGraph& tg, const DelayCalculator& dc, GraphVisitor& visitor) override {
+            for(NodeId node : tg.nodes()) {
+                visitor.do_slack_traverse_node(tg, dc, node);
+            }
+        }
+
+        void do_reset_impl(const TimingGraph& tg, GraphVisitor& visitor) override {
+            for(NodeId node_id : tg.nodes()) {
+                visitor.do_reset_node(node_id);
+            }
+            for(EdgeId edge_id : tg.edges()) {
+                visitor.do_reset_edge(edge_id);
+            }
+        }
+
+        size_t num_unconstrained_startpoints_impl() const override { return num_unconstrained_startpoints_; }
+        size_t num_unconstrained_endpoints_impl() const override { return num_unconstrained_endpoints_; }
+    private:
+        size_t num_unconstrained_startpoints_ = 0;
+        size_t num_unconstrained_endpoints_ = 0;
+};
+
+} //namepsace

--- a/libtatum/tatum/graph_walkers/SerialIncrWalker.hpp
+++ b/libtatum/tatum/graph_walkers/SerialIncrWalker.hpp
@@ -8,8 +8,48 @@
 namespace tatum {
 
 /**
- * A simple serial graph walker which traverses the timing graph in a levelized
- * manner.
+ * Controls how timing tags are invalidated during the incremental traversal.
+ *
+ * If TATUM_INCR_BLOCK_INVALIDATION is defined: 
+ *      All of a nodes tags associated with an invalidated edge are invalidated.
+ *      This is a robust but pessimisitc approach (it invalidates more tags than
+ *      strictly required). As a result all nodes processed will report having been
+ *      modified, meaning their decendents/predecessors will also be invalidated
+ *      even if in reality the recalculated tags are identical to the previous ones
+ *      (i.e. nothing has really changed).
+ *
+ * Ohterwise, the analyzer performs edge invalidation:
+ *      Only node tags which are dominanted by an invalidated edge are invalidated.
+ *      This is a less pessimistic approach, and means when processed nodes which
+ *      don't have any changed tags will report as being unmodified. This significantly
+ *      prunes the amount of the timing graph which needs to be updated (as unmodified
+ *      nodes don't need to invalidate their decendents/predecessors.
+ */
+//#define TATUM_INCR_BLOCK_INVALIDATION
+
+/**
+ * A serial graph walker which traverses the timing graph in a levelized
+ * manner. Unlike SerialWalker it attempts to incrementally (rather than
+ * fully) update based on invalidated edges.
+ *
+ * To performan an incremental traversal, the st of invalidated edges
+ * is processed to identify nodes which will need to be re-evaluated for
+ * the arrival and/or required traversals.
+ *
+ * These nodes are then stored in per-level queues for the arrival/required
+ * traversals in incr_arr_update_/incr_req_update_, which also stores the
+ * level range which needs to be considered.
+ *
+ * These queues are processed by do_arrival_traversal_impl()/
+ * do_required_traversal_impl() to update the analysis result. Importantly,
+ * incr_arr_update_/incr_req_update_ may be modified while 
+ * do_arrival_traversal_impl()/do_required_traversal_impl() are running, since
+ * as nodes are modified their decendents/predessors may need to be updated
+ * as well.
+ *
+ * Note that this graph walker assumes that timing constraints aren't changed
+ * and so do_arrival_pre_traversal_impl() / do_required_pre_traversal_impl()
+ * should only be called once (on the first analysis)
  */
 class SerialIncrWalker : public TimingGraphWalker {
     protected:
@@ -62,26 +102,24 @@ class SerialIncrWalker : public TimingGraphWalker {
         void do_arrival_traversal_impl(const TimingGraph& tg, const TimingConstraints& tc, const DelayCalculator& dc, GraphVisitor& visitor) override {
             prepare_incr_update(tg);
 
-            //std::cout << "Arr Levels " << incr_arr_update_.min_level << ": " << incr_arr_update_.max_level << "\n";
             for(int level_idx = incr_arr_update_.min_level; level_idx <= incr_arr_update_.max_level; ++level_idx) {
                 LevelId level(level_idx);
 
                 auto& level_nodes = incr_arr_update_.nodes_to_process[level_idx];
 
+                //Sorting the level nodes tends to help memory locality, since the
+                //timing graph is laid out in traversal order
                 sort(level_nodes);
-
-                //std::cout << "Processing Arr Level " << size_t(level) << ": " << level_nodes.size() << " nodes\n";
 
                 for (NodeId node : level_nodes) {
 
-                    //std::cout << "  Processing Arr " << node << "\n";
                     invalidate_node_for_arrival_traversal(node, tg, visitor);
 
                     bool node_updated = visitor.do_arrival_traverse_node(tg, tc, dc, node);
 
                     if (node_updated) {
                         //Record that this node was updated, for later efficient slack update
-                        enqueue_slack_node(node);
+                        enqueue_modified_node(node);
 
                         //Queue this node's downstream dependencies for updating
                         for (EdgeId edge : tg.node_out_edges(node)) {
@@ -91,36 +129,28 @@ class SerialIncrWalker : public TimingGraphWalker {
                     }
                 }
             }
-            //std::cout  << "Arr Processed " << incr_arr_update_.total_levels_to_process() << " levels, " << incr_arr_update_.total_nodes_to_process() << " nodes\n";
         }
 
         void do_required_traversal_impl(const TimingGraph& tg, const TimingConstraints& tc, const DelayCalculator& dc, GraphVisitor& visitor) override {
 
-            //std::cout << "Req Levels " << incr_req_update_.max_level << ": " << incr_req_update_.min_level << "\n";
             for(int level_idx = incr_req_update_.max_level; level_idx >= incr_req_update_.min_level; --level_idx) {
                 LevelId level(level_idx);
 
                 auto& level_nodes = incr_req_update_.nodes_to_process[level_idx];
 
+                //Sorting the level nodes tends to help memory locality, since the
+                //timing graph is laid out in traversal order
                 sort(level_nodes);
 
-                //std::cout << "Processing Req Level " << size_t(level) << ": " << level_nodes.size() << " nodes\n";
-
                 for (NodeId node : level_nodes) {
-
-                    //std::cout << "  Processing Req " << node << "\n";
-
                     invalidate_node_for_required_traversal(node, tg, visitor);
                     bool node_updated = visitor.do_required_traverse_node(tg, tc, dc, node);
 
                     if (node_updated) {
-
-                        //std::cout << "    Enqueing slack\n";
-
                         //Record that this node was updated, for later efficient slack update
-                        enqueue_slack_node(node);
+                        enqueue_modified_node(node);
 
-                        //Queue this node's downstream dependencies for updating
+                        //Queue this node's upstream dependencies for updating
                         for (EdgeId edge : tg.node_in_edges(node)) {
                             NodeId src_node = tg.edge_src_node(edge);
 
@@ -129,7 +159,6 @@ class SerialIncrWalker : public TimingGraphWalker {
                     }
                 }
             }
-            //std::cout  << "Req Processed " << incr_req_update_.total_levels_to_process() << " levels, " << incr_req_update_.total_nodes_to_process() << " nodes\n";
         }
 
         void do_update_slack_impl(const TimingGraph& tg, const DelayCalculator& dc, GraphVisitor& visitor) override {
@@ -208,18 +237,18 @@ class SerialIncrWalker : public TimingGraphWalker {
         }
 
         void prepare_incr_update(const TimingGraph& tg) {
+            //Reset incremental traversal tracking data
             clear_modified();
             resize_incr_update_levels(tg);
             incr_arr_update_.clear(tg);
             incr_req_update_.clear(tg);
-
 
             incr_arr_update_.min_level = size_t(*(tg.levels().end() - 1));
             incr_arr_update_.max_level = size_t(*tg.levels().begin());
             incr_req_update_.min_level = size_t(*(tg.levels().end() - 1));
             incr_req_update_.max_level = size_t(*tg.levels().begin());
 
-            //std::cout << "Invalidated Edges: " << invalidated_edges_.size() << " / " << tg.edges().size() << " (" << invalidated_edges_.size() / tg.edges().size() << ")\n";
+            //Process the externally invalidated edges to prepare for the incremental traversal
             for (EdgeId edge : invalidated_edges_) {
                 NodeId snk_node = tg.edge_sink_node(edge);
                 enqueue_arr_node(tg, snk_node, edge);
@@ -229,19 +258,20 @@ class SerialIncrWalker : public TimingGraphWalker {
             }
         }
 
+        //Enqueues a node for arrival time processing which was invalidated by invalidated_edge
         void enqueue_arr_node(const TimingGraph& tg, NodeId node, EdgeId invalidated_edge) {
-            //std::cout << "  Enqueing arr " << node << "\n";
             invalidate_edge_impl(invalidated_edge);
             incr_arr_update_.enqueue_node(tg, node);
         }
 
+        //Enqueues a node for required time processing which was invalidated by invalidated_edge
         void enqueue_req_node(const TimingGraph& tg, NodeId node, EdgeId invalidated_edge) {
-            //std::cout << "  Enqueing req " << node << "\n";
             invalidate_edge_impl(invalidated_edge);
             incr_req_update_.enqueue_node(tg, node);
         }
 
-        void enqueue_slack_node(const NodeId node) {
+        //Record the specified node as having been modified
+        void enqueue_modified_node(const NodeId node) {
             if (is_modified(node)) return;
 
             mark_modified(node);
@@ -250,69 +280,81 @@ class SerialIncrWalker : public TimingGraphWalker {
         }
 
         void invalidate_node_for_arrival_traversal(const NodeId node, const TimingGraph& tg, GraphVisitor& visitor) {
-            if (0) { //Block invalidation
-                visitor.do_reset_node_arrival_tags(node);
-            } else { //Edge invalidation
-                for (EdgeId edge : tg.node_in_edges(node)) {
-                    if (not_invalidated(edge)) continue;
-                    //Data arrival tags track their associated origin node (i.e. dominant
-                    //edge which determines the tag value). Rather than invalidate all
-                    //tags to ensure the correctly updated tag when the node is re-traversed,
-                    //we can get away with only invalidating the tag when the dominant edge
-                    //is invalidated.
+
+#ifdef TATUM_INCR_BLOCK_INVALIDATION
+            //Block invalidation
+            //
+            //Invalidates the entire node (all the nodes arrival tags)
+            //As a result, when processed the node will be re-computed from scratch
+            visitor.do_reset_node_arrival_tags(node);
+#else
+            //Edge invalidation
+            for (EdgeId edge : tg.node_in_edges(node)) {
+                if (not_invalidated(edge)) continue;
+                //Data arrival tags track their associated origin node (i.e. dominant
+                //edge which determines the tag value). Rather than invalidate all
+                //tags to ensure the correctly updated tag when the node is re-traversed,
+                //we can get away with only invalidating the tag when the dominant edge
+                //is invalidated.
+                //
+                //This ensures that cases where non-dominate edges change delay value,
+                //but not in ways which effect the tag value, we detect that the tag
+                //is 'unchanged', which helps keep the number of updated nodes small.
+                NodeId src_node = tg.edge_src_node(edge);
+                visitor.do_reset_node_arrival_tags_from_origin(node, /*origin=*/src_node);
+
+                //At SOURCE/SINK nodes clock launch/capture tags are converted into
+                //data arrival/required tags, so we also need to carefully reset those
+                //tags as well (since they don't track origin nodes this must be done
+                //seperately).
+                EdgeType edge_type = tg.edge_type(edge);
+                if (edge_type == EdgeType::PRIMITIVE_CLOCK_CAPTURE) {
+                    //We mark required times on sinks based the clock capture time during
+                    //the arrival traversal.
                     //
-                    //This ensures that cases where non-dominate edges change delay value,
-                    //but not in ways which effect the tag value, we detect that the tag
-                    //is 'unchanged', which helps keep the number of updated nodes small.
-                    NodeId src_node = tg.edge_src_node(edge);
-                    visitor.do_reset_node_arrival_tags_from_origin(node, /*origin=*/src_node);
+                    //Therefore we need to invalidate the data required times (so they are
+                    //re-calculated correctly) when the clock caputre edge has been 
+                    //invalidated. Note that we don't need to enqueue the sink node for 
+                    //required time traversal, since the required time will be updated during
+                    //the arrival traversasl.
+                    visitor.do_reset_node_required_tags(node);
 
-                    //At SOURCE/SINK nodes clock launch/capture tags are converted into
-                    //data arrival/required tags, so we also need to carefully reset those
-                    //tags as well (since they don't track origin nodes this must be done
-                    //seperately).
-                    EdgeType edge_type = tg.edge_type(edge);
-                    if (edge_type == EdgeType::PRIMITIVE_CLOCK_CAPTURE) {
-                        //We mark required times on sinks based the clock capture time during
-                        //the arrival traversal.
-                        //
-                        //Therefore we need to invalidate the data required times (so they are
-                        //re-calculated correctly) when the clock caputre edge has been 
-                        //invalidated. Note that we don't need to enqueue the sink node for 
-                        //required time traversal, since the required time will be updated during
-                        //the arrival traversasl.
-                        visitor.do_reset_node_required_tags(node);
-
-                        //However, since the required time traversal doesn't update the sink node,
-                        //it's dependent nodes won't be enqueued for processing, even if the required
-                        //times changed, so we explicitly do that here
-                        for (EdgeId sink_in_edge : tg.node_in_edges(node)) {
-                            NodeId sink_src_node = tg.edge_src_node(sink_in_edge);
-                            enqueue_req_node(tg, sink_src_node, sink_in_edge);
-                        }
-                    } else if (edge_type == EdgeType::PRIMITIVE_CLOCK_LAUNCH) {
-                        //On propagating to a SOURCE node, CLOCK_LAUNCH becomes DATA_ARRIVAL
-                        //we therefore invalidate any outstanding arrival tags if the clock launch
-                        //edge has been invalidated.
-                        //
-                        //This ensures the correct data arrivaltags are generated
-                        visitor.do_reset_node_arrival_tags(node);
+                    //However, since the required time traversal doesn't update the sink node,
+                    //it's dependent nodes won't be enqueued for processing, even if the required
+                    //times changed, so we explicitly do that here
+                    for (EdgeId sink_in_edge : tg.node_in_edges(node)) {
+                        NodeId sink_src_node = tg.edge_src_node(sink_in_edge);
+                        enqueue_req_node(tg, sink_src_node, sink_in_edge);
                     }
+                } else if (edge_type == EdgeType::PRIMITIVE_CLOCK_LAUNCH) {
+                    //On propagating to a SOURCE node, CLOCK_LAUNCH becomes DATA_ARRIVAL
+                    //we therefore invalidate any outstanding arrival tags if the clock launch
+                    //edge has been invalidated.
+                    //
+                    //This ensures the correct data arrivaltags are generated
+                    visitor.do_reset_node_arrival_tags(node);
                 }
+            }
+#endif
             }
         }
 
         void invalidate_node_for_required_traversal(const NodeId node, const TimingGraph& tg, GraphVisitor& visitor) {
-            if (0) { //Block invalidation
-                visitor.do_reset_node_required_tags(node);
-            } else { //Edge invalidation
-                for (EdgeId edge : tg.node_out_edges(node)) {
-                    if (not_invalidated(edge)) continue;
+#ifdef TATUM_INCR_BLOCK_INVALIDATION
+            //Block invalidation
+            //
+            //Invalidates the entire node (all the nodes arrival tags)
+            //As a result, when processed the node will be re-computed from scratch
+            visitor.do_reset_node_required_tags(node);
+#else
+            //Edge invalidation
+            for (EdgeId edge : tg.node_out_edges(node)) {
+                if (not_invalidated(edge)) continue;
 
-                    NodeId snk_node = tg.edge_sink_node(edge);
-                    visitor.do_reset_node_required_tags_from_origin(node, /*origin=*/snk_node);
-                }
+                NodeId snk_node = tg.edge_sink_node(edge);
+                visitor.do_reset_node_required_tags_from_origin(node, /*origin=*/snk_node);
             }
+#endif
         }
 
         void resize_incr_update_levels(const TimingGraph& tg) {
@@ -320,9 +362,16 @@ class SerialIncrWalker : public TimingGraphWalker {
             incr_req_update_.nodes_to_process.resize(tg.levels().size());
         }
 
+        /*
+         * Helper struct to record incremental traversal information
+         */
         struct t_incr_traversal_update {
             public:
+
+                //The nodes per-level which need to be updated/processed
                 std::vector<std::vector<NodeId>> nodes_to_process;
+
+                //The range of levels which need to be updated
                 int min_level = 0;
                 int max_level = 0;
 
@@ -374,17 +423,21 @@ class SerialIncrWalker : public TimingGraphWalker {
                     node_is_enqueued[node] = true;
                 }
 
+                //Bitset to record whether a node has already been enqueued
                 tatum::util::linear_map<NodeId,bool> node_is_enqueued;
 
         };
 
+        //State info about the incremental arr/req updates
         t_incr_traversal_update incr_arr_update_;
         t_incr_traversal_update incr_req_update_;
 
+        //Set of invalidated edges, and bitset for membership
         std::vector<EdgeId> invalidated_edges_;
         tatum::util::linear_map<EdgeId,bool> edge_invalidated_;
 
-        std::vector<NodeId> nodes_modified_; //Nodes which have been modified during timing update
+        //Nodes which have been modified during timing update, and bitset for membership
+        std::vector<NodeId> nodes_modified_; 
         tatum::util::linear_map<NodeId,bool> node_is_modified_;
 
         size_t num_unconstrained_startpoints_ = 0;

--- a/libtatum/tatum/graph_walkers/SerialIncrWalker.hpp
+++ b/libtatum/tatum/graph_walkers/SerialIncrWalker.hpp
@@ -64,6 +64,10 @@ class SerialIncrWalker : public TimingGraphWalker {
 
                 for (NodeId node : level_nodes) {
 
+                    //std::cout << "  Processing Arr " << node << "\n";
+
+                    visitor.do_reset_node_arrival_tags(node);
+
                     bool node_updated = visitor.do_arrival_traverse_node(tg, tc, dc, node);
 
                     if (node_updated) {
@@ -105,6 +109,9 @@ class SerialIncrWalker : public TimingGraphWalker {
                 std::cout << "Processing Req Level " << size_t(level) << ": " << level_nodes.size() << " nodes\n";
 
                 for (NodeId node : level_nodes) {
+
+                    //std::cout << "  Processing Req " << node << "\n";
+                    visitor.do_reset_node_required_tags(node);
 
                     bool node_updated = visitor.do_required_traverse_node(tg, tc, dc, node);
 

--- a/libtatum/tatum/graph_walkers/SerialIncrWalker.hpp
+++ b/libtatum/tatum/graph_walkers/SerialIncrWalker.hpp
@@ -84,7 +84,7 @@ class SerialIncrWalker : public TimingGraphWalker {
              */
 
             const auto& rev_levels = tg.reversed_levels();
-            auto rev_level_itr = rev_levels.begin() + 1;
+            auto rev_level_itr = rev_levels.begin();
 
             for(NodeId node_id : tg.level_nodes(*rev_level_itr)) {
                 next_level_nodes_to_process_->push_back(node_id);
@@ -105,7 +105,9 @@ class SerialIncrWalker : public TimingGraphWalker {
 
                         //Record that this node was updated, for later efficient slack update
                         nodes_to_update_slack_.emplace_back(node);
+                    }
 
+                    if (node_updated || level_id == *rev_levels.begin()) {
                         //Queue this node's downstream dependencies for updating
                         for (EdgeId in_edge : tg.node_in_edges(node)) {
                             NodeId src_node = tg.edge_src_node(in_edge);

--- a/libtatum/tatum/graph_walkers/SerialIncrWalker.hpp
+++ b/libtatum/tatum/graph_walkers/SerialIncrWalker.hpp
@@ -226,8 +226,8 @@ class SerialIncrWalker : public TimingGraphWalker {
 
         struct t_incr_traversal_update {
             std::vector<std::vector<NodeId>> nodes_to_process;
-            int min_level;
-            int max_level;
+            int min_level = 0;
+            int max_level = 0;
 
             void enqueue_node(const TimingGraph& tg, NodeId node) {
                 int level = size_t(tg.node_level(node));

--- a/libtatum/tatum/graph_walkers/SerialIncrWalker.hpp
+++ b/libtatum/tatum/graph_walkers/SerialIncrWalker.hpp
@@ -65,7 +65,7 @@ class SerialIncrWalker : public TimingGraphWalker {
 
                 for (NodeId node : level_nodes) {
 
-                    std::cout << "  Processing Arr " << node << "\n";
+                    //std::cout << "  Processing Arr " << node << "\n";
 
                     bool node_updated = visitor.do_arrival_traverse_node(tg, tc, dc, node);
 
@@ -102,7 +102,7 @@ class SerialIncrWalker : public TimingGraphWalker {
 
                 for (NodeId node : level_nodes) {
 
-                    std::cout << "  Processing Req " << node << "\n";
+                    //std::cout << "  Processing Req " << node << "\n";
 
                     bool node_updated = visitor.do_required_traverse_node(tg, tc, dc, node);
 
@@ -232,7 +232,7 @@ class SerialIncrWalker : public TimingGraphWalker {
 
             }
 
-            std::cout << "  Enqueing arr " << node << "\n";
+            //std::cout << "  Enqueing arr " << node << "\n";
             incr_arr_update_.enqueue_node(tg, node);
         }
 
@@ -244,7 +244,7 @@ class SerialIncrWalker : public TimingGraphWalker {
                 visitor.do_reset_node_required_tags_from_origin(node, snk_node);
             }
 
-            std::cout << "  Enqueing req " << node << "\n";
+            //std::cout << "  Enqueing req " << node << "\n";
             incr_req_update_.enqueue_node(tg, node);
         }
 

--- a/libtatum/tatum/graph_walkers/SerialIncrWalker.hpp
+++ b/libtatum/tatum/graph_walkers/SerialIncrWalker.hpp
@@ -54,7 +54,7 @@ class SerialIncrWalker : public TimingGraphWalker {
             resize_incr_update_levels(tg);
             prepare_incr_arrival_update(tg, visitor);
 
-            std::cout << "Arr Levels " << incr_arr_update_.min_level << ": " << incr_arr_update_.max_level << "\n";
+            //std::cout << "Arr Levels " << incr_arr_update_.min_level << ": " << incr_arr_update_.max_level << "\n";
             for(int level_idx = incr_arr_update_.min_level; level_idx <= incr_arr_update_.max_level; ++level_idx) {
                 LevelId level(level_idx);
 
@@ -62,7 +62,7 @@ class SerialIncrWalker : public TimingGraphWalker {
 
                 uniquify(level_nodes);
 
-                std::cout << "Processing Arr Level " << size_t(level) << ": " << level_nodes.size() << " nodes\n";
+                //std::cout << "Processing Arr Level " << size_t(level) << ": " << level_nodes.size() << " nodes\n";
 
                 for (NodeId node : level_nodes) {
 
@@ -82,7 +82,7 @@ class SerialIncrWalker : public TimingGraphWalker {
                     }
                 }
             }
-            std::cout  << "Arr Processed " << incr_arr_update_.total_levels_to_process() << " levels, " << incr_arr_update_.total_nodes_to_process() << " nodes\n";
+            //std::cout  << "Arr Processed " << incr_arr_update_.total_levels_to_process() << " levels, " << incr_arr_update_.total_nodes_to_process() << " nodes\n";
             complete_incr_arrival_update(tg);
         }
 
@@ -90,7 +90,7 @@ class SerialIncrWalker : public TimingGraphWalker {
             resize_incr_update_levels(tg);
             prepare_incr_required_update(tg, visitor);
 
-            std::cout << "Req Levels " << incr_req_update_.max_level << ": " << incr_req_update_.min_level << "\n";
+            //std::cout << "Req Levels " << incr_req_update_.max_level << ": " << incr_req_update_.min_level << "\n";
             for(int level_idx = incr_req_update_.max_level; level_idx >= incr_req_update_.min_level; --level_idx) {
                 LevelId level(level_idx);
 
@@ -98,7 +98,7 @@ class SerialIncrWalker : public TimingGraphWalker {
 
                 uniquify(level_nodes);
 
-                std::cout << "Processing Req Level " << size_t(level) << ": " << level_nodes.size() << " nodes\n";
+                //std::cout << "Processing Req Level " << size_t(level) << ": " << level_nodes.size() << " nodes\n";
 
                 for (NodeId node : level_nodes) {
 
@@ -122,7 +122,7 @@ class SerialIncrWalker : public TimingGraphWalker {
                     }
                 }
             }
-            std::cout  << "Req Processed " << incr_req_update_.total_levels_to_process() << " levels, " << incr_req_update_.total_nodes_to_process() << " nodes\n";
+            //std::cout  << "Req Processed " << incr_req_update_.total_levels_to_process() << " levels, " << incr_req_update_.total_nodes_to_process() << " nodes\n";
 
             complete_incr_required_update(tg);
         }
@@ -130,7 +130,7 @@ class SerialIncrWalker : public TimingGraphWalker {
         void do_update_slack_impl(const TimingGraph& tg, const DelayCalculator& dc, GraphVisitor& visitor) override {
             uniquify(nodes_to_update_slack_);
 
-            std::cout << "Processing slack updates for " << nodes_to_update_slack_.size() << " nodes\n";
+            //std::cout << "Processing slack updates for " << nodes_to_update_slack_.size() << " nodes\n";
 
             for(NodeId node : nodes_to_update_slack_) {
                 //std::cout << "  Processing slack " << node << "\n";
@@ -171,7 +171,7 @@ class SerialIncrWalker : public TimingGraphWalker {
             incr_req_update_.min_level = size_t(*(tg.levels().end() - 1));
             incr_req_update_.max_level = size_t(*tg.levels().begin());
 
-            std::cout << "Invalidated Edges: " << invalidated_edges_.size() << " / " << tg.edges().size() << " (" << invalidated_edges_.size() / tg.edges().size() << ")\n";
+            //std::cout << "Invalidated Edges: " << invalidated_edges_.size() << " / " << tg.edges().size() << " (" << invalidated_edges_.size() / tg.edges().size() << ")\n";
             for (EdgeId edge : invalidated_edges_) {
                 NodeId node = tg.edge_sink_node(edge);
 

--- a/libtatum/tatum/graph_walkers/SerialIncrWalker.hpp
+++ b/libtatum/tatum/graph_walkers/SerialIncrWalker.hpp
@@ -281,10 +281,6 @@ class SerialIncrWalker : public TimingGraphWalker {
             }
 
             size_t total_nodes_to_process() {
-                if (!min_level || !max_level) {
-                    return 0;
-                }
-
                 size_t cnt = 0;
                 for (int level = min_level; level <= max_level; ++level) {
                     cnt += nodes_to_process[level].size();

--- a/libtatum/tatum/graph_walkers/SerialIncrWalker.hpp
+++ b/libtatum/tatum/graph_walkers/SerialIncrWalker.hpp
@@ -88,14 +88,6 @@ class SerialIncrWalker : public TimingGraphWalker {
         }
 
         void do_required_traversal_impl(const TimingGraph& tg, const TimingConstraints& tc, const DelayCalculator& dc, GraphVisitor& visitor) override {
-            /*
-             *for(LevelId level_id : tg.reversed_levels()) {
-             *    for(NodeId node_id : tg.level_nodes(level_id)) {
-             *        visitor.do_required_traverse_node(tg, tc, dc, node_id);
-             *    }
-             *}
-             */
-
             prepare_incr_required_update(tg);
 
             std::cout << "Req Levels " << incr_req_update_.max_level << ": " << incr_req_update_.min_level << "\n";

--- a/libtatum/tatum/graph_walkers/SerialIncrWalker.hpp
+++ b/libtatum/tatum/graph_walkers/SerialIncrWalker.hpp
@@ -42,25 +42,90 @@ class SerialIncrWalker : public TimingGraphWalker {
         }
 
         void do_arrival_traversal_impl(const TimingGraph& tg, const TimingConstraints& tc, const DelayCalculator& dc, GraphVisitor& visitor) override {
-            for(LevelId level_id : tg.levels()) {
-                for(NodeId node_id : tg.level_nodes(level_id)) {
-                    visitor.do_arrival_traverse_node(tg, tc, dc, node_id);
+            const auto& levels = tg.levels();
+            auto level_itr = levels.begin() + 1;
+
+            for(NodeId node_id : tg.level_nodes(*level_itr)) {
+                next_level_nodes_to_process_->push_back(node_id);
+            }
+
+            while(prepare_to_traverse_next_level()) {
+                TATUM_ASSERT(level_itr != levels.end());
+                LevelId level_id = *level_itr++;
+
+                std::cout << "Processing Arr Level " << size_t(level_id) << ": " << level_nodes_to_process_->size() << " nodes\n";
+
+                for (NodeId node : *level_nodes_to_process_) {
+
+                    bool node_updated = visitor.do_arrival_traverse_node(tg, tc, dc, node);
+
+                    if (node_updated) {
+
+                        //Record that this node was updated, for later efficient slack update
+                        nodes_to_update_slack_.emplace_back(node);
+
+                        //Queue this node's downstream dependencies for updating
+                        for (EdgeId out_edge : tg.node_out_edges(node)) {
+                            NodeId snk_node = tg.edge_sink_node(out_edge);
+                            next_level_nodes_to_process_->push_back(snk_node);
+                        }
+                    }
                 }
             }
         }
 
         void do_required_traversal_impl(const TimingGraph& tg, const TimingConstraints& tc, const DelayCalculator& dc, GraphVisitor& visitor) override {
-            for(LevelId level_id : tg.reversed_levels()) {
-                for(NodeId node_id : tg.level_nodes(level_id)) {
-                    visitor.do_required_traverse_node(tg, tc, dc, node_id);
+            /*
+             *for(LevelId level_id : tg.reversed_levels()) {
+             *    for(NodeId node_id : tg.level_nodes(level_id)) {
+             *        visitor.do_required_traverse_node(tg, tc, dc, node_id);
+             *    }
+             *}
+             */
+
+            const auto& rev_levels = tg.reversed_levels();
+            auto rev_level_itr = rev_levels.begin() + 1;
+
+            for(NodeId node_id : tg.level_nodes(*rev_level_itr)) {
+                next_level_nodes_to_process_->push_back(node_id);
+            }
+
+            while(prepare_to_traverse_next_level()) {
+                TATUM_ASSERT(rev_level_itr != rev_levels.end());
+                LevelId level_id = *rev_level_itr++;
+
+                std::cout << "Processing Req Level " << size_t(level_id) << ": " << level_nodes_to_process_->size() << " nodes\n";
+
+
+                for (NodeId node : *level_nodes_to_process_) {
+
+                    bool node_updated = visitor.do_required_traverse_node(tg, tc, dc, node);
+
+                    if (node_updated) {
+
+                        //Record that this node was updated, for later efficient slack update
+                        nodes_to_update_slack_.emplace_back(node);
+
+                        //Queue this node's downstream dependencies for updating
+                        for (EdgeId in_edge : tg.node_in_edges(node)) {
+                            NodeId src_node = tg.edge_src_node(in_edge);
+                            next_level_nodes_to_process_->push_back(src_node);
+                        }
+                    }
                 }
             }
         }
 
         void do_update_slack_impl(const TimingGraph& tg, const DelayCalculator& dc, GraphVisitor& visitor) override {
-            for(NodeId node : tg.nodes()) {
+            uniquify(nodes_to_update_slack_);
+
+            std::cout << "Processing slack updates for " << nodes_to_update_slack_.size() << " nodes\n";
+
+            for(NodeId node : nodes_to_update_slack_) {
                 visitor.do_slack_traverse_node(tg, dc, node);
             }
+
+            nodes_to_update_slack_.clear();
         }
 
         void do_reset_impl(const TimingGraph& tg, GraphVisitor& visitor) override {
@@ -75,8 +140,32 @@ class SerialIncrWalker : public TimingGraphWalker {
         size_t num_unconstrained_startpoints_impl() const override { return num_unconstrained_startpoints_; }
         size_t num_unconstrained_endpoints_impl() const override { return num_unconstrained_endpoints_; }
     private:
+
+        bool prepare_to_traverse_next_level() {
+            //Clear the nodes processed at the current level
+            level_nodes_to_process_->clear();
+
+            //Sort an uniquify nodes to update at next level
+            uniquify(*next_level_nodes_to_process_);
+
+            //Flip nodes to process for next level queues
+            std::swap(level_nodes_to_process_, next_level_nodes_to_process_);
+
+            return !level_nodes_to_process_->empty();
+        }
+
+        void uniquify(std::vector<NodeId>& nodes) {
+            std::sort(nodes.begin(), nodes.end());
+            nodes.erase(std::unique(nodes.begin(), nodes.end()),
+                        nodes.end());
+        }
+
         size_t num_unconstrained_startpoints_ = 0;
         size_t num_unconstrained_endpoints_ = 0;
+
+        std::unique_ptr<std::vector<NodeId>> level_nodes_to_process_ = std::make_unique<std::vector<NodeId>>();
+        std::unique_ptr<std::vector<NodeId>> next_level_nodes_to_process_ = std::make_unique<std::vector<NodeId>>();
+        std::vector<NodeId> nodes_to_update_slack_;
 };
 
 } //namepsace

--- a/libtatum/tatum/graph_walkers/SerialIncrWalker.hpp
+++ b/libtatum/tatum/graph_walkers/SerialIncrWalker.hpp
@@ -53,7 +53,7 @@ class SerialIncrWalker : public TimingGraphWalker {
             prepare_incr_arrival_update(tg, visitor);
 
             std::cout << "Arr Levels " << incr_arr_update_.min_level << ": " << incr_arr_update_.max_level << "\n";
-            for(size_t level_idx = size_t(incr_arr_update_.min_level); level_idx <= size_t(incr_arr_update_.max_level); ++level_idx) {
+            for(int level_idx = incr_arr_update_.min_level; level_idx <= incr_arr_update_.max_level; ++level_idx) {
                 LevelId level(level_idx);
 
                 auto& level_nodes = incr_arr_update_.nodes_to_process[level_idx];
@@ -89,7 +89,7 @@ class SerialIncrWalker : public TimingGraphWalker {
             prepare_incr_required_update(tg, visitor);
 
             std::cout << "Req Levels " << incr_req_update_.max_level << ": " << incr_req_update_.min_level << "\n";
-            for(int level_idx = size_t(incr_req_update_.max_level); level_idx >= int(size_t(incr_req_update_.min_level)); --level_idx) {
+            for(int level_idx = incr_req_update_.max_level; level_idx >= incr_req_update_.min_level; --level_idx) {
                 LevelId level(level_idx);
 
                 auto& level_nodes = incr_req_update_.nodes_to_process[level_idx];
@@ -156,13 +156,13 @@ class SerialIncrWalker : public TimingGraphWalker {
         void prepare_incr_arrival_update(const TimingGraph& tg, GraphVisitor& visitor) {
             incr_arr_update_.nodes_to_process.resize(tg.levels().size());
             if (incr_arr_update_.min_level && incr_arr_update_.max_level) {
-                for (int level = size_t(incr_arr_update_.min_level); level <= size_t(incr_arr_update_.max_level); ++level) {
+                for (int level = incr_arr_update_.min_level; level <= incr_arr_update_.max_level; ++level) {
                     incr_arr_update_.nodes_to_process[level].clear();
                 }
             }
 
-            incr_arr_update_.min_level = *(tg.levels().end() - 1);
-            incr_arr_update_.max_level = *tg.levels().begin();
+            incr_arr_update_.min_level = size_t(*(tg.levels().end() - 1));
+            incr_arr_update_.max_level = size_t(*tg.levels().begin());
 
             /*
              *for (LevelId level : tg.levels()) {
@@ -181,13 +181,13 @@ class SerialIncrWalker : public TimingGraphWalker {
         void prepare_incr_required_update(const TimingGraph& tg, GraphVisitor& visitor) {
             incr_req_update_.nodes_to_process.resize(tg.levels().size());
             if (incr_req_update_.min_level && incr_req_update_.max_level) {
-                for (int level = size_t(incr_req_update_.min_level); level <= size_t(incr_req_update_.max_level); ++level) {
+                for (int level = incr_req_update_.min_level; level <= incr_req_update_.max_level; ++level) {
                     incr_req_update_.nodes_to_process[level].clear();
                 }
             }
 
-            incr_req_update_.min_level = *(tg.levels().end() - 1);
-            incr_req_update_.max_level = *tg.levels().begin();
+            incr_req_update_.min_level = size_t(*(tg.levels().end() - 1));
+            incr_req_update_.max_level = size_t(*tg.levels().begin());
 
             /*
              *for (LevelId level : tg.levels()) {
@@ -226,13 +226,13 @@ class SerialIncrWalker : public TimingGraphWalker {
 
         struct t_incr_traversal_update {
             std::vector<std::vector<NodeId>> nodes_to_process;
-            LevelId min_level;
-            LevelId max_level;
+            int min_level;
+            int max_level;
 
             void enqueue_node(const TimingGraph& tg, NodeId node) {
-                LevelId level = tg.node_level(node);
+                int level = size_t(tg.node_level(node));
 
-                nodes_to_process[size_t(level)].push_back(node);
+                nodes_to_process[level].push_back(node);
                 min_level = std::min(min_level, level);
                 max_level = std::max(max_level, level);
             }
@@ -243,7 +243,7 @@ class SerialIncrWalker : public TimingGraphWalker {
                 }
 
                 size_t cnt = 0;
-                for (int level = size_t(min_level); level <= size_t(max_level); ++level) {
+                for (int level = min_level; level <= max_level; ++level) {
                     cnt += nodes_to_process[level].size();
                 }
                 return cnt;

--- a/libtatum/tatum/graph_walkers/SerialIncrWalker.hpp
+++ b/libtatum/tatum/graph_walkers/SerialIncrWalker.hpp
@@ -78,7 +78,6 @@ class SerialIncrWalker : public TimingGraphWalker {
                             NodeId snk_node = tg.edge_sink_node(edge);
                             enqueue_arr_node(tg, snk_node, edge, visitor);
                         }
-                    } else {
                     }
                 }
             }

--- a/libtatum/tatum/graph_walkers/SerialIncrWalker.hpp
+++ b/libtatum/tatum/graph_walkers/SerialIncrWalker.hpp
@@ -12,6 +12,10 @@ namespace tatum {
  */
 class SerialIncrWalker : public TimingGraphWalker {
     protected:
+        void invalidate_edge_impl(const EdgeId /*edge*/) override {
+            //TODO: handle this
+        }
+
         void do_arrival_pre_traversal_impl(const TimingGraph& tg, const TimingConstraints& tc, GraphVisitor& visitor) override {
             size_t num_unconstrained = 0;
 

--- a/libtatum/tatum/graph_walkers/SerialWalker.hpp
+++ b/libtatum/tatum/graph_walkers/SerialWalker.hpp
@@ -88,9 +88,11 @@ class SerialWalker : public TimingGraphWalker {
             for(NodeId node_id : tg.nodes()) {
                 visitor.do_reset_node(node_id);
             }
+#ifdef TATUM_CALCULATE_EDGE_SLACKS
             for(EdgeId edge_id : tg.edges()) {
                 visitor.do_reset_edge(edge_id);
             }
+#endif
         }
 
         size_t num_unconstrained_startpoints_impl() const override { return num_unconstrained_startpoints_; }

--- a/libtatum/tatum/graph_walkers/SerialWalker.hpp
+++ b/libtatum/tatum/graph_walkers/SerialWalker.hpp
@@ -12,6 +12,10 @@ namespace tatum {
  */
 class SerialWalker : public TimingGraphWalker {
     protected:
+        void invalidate_edge_impl(const EdgeId /*edge*/) override {
+            //Do nothing, this walker only does full updates
+        }
+
         void do_arrival_pre_traversal_impl(const TimingGraph& tg, const TimingConstraints& tc, GraphVisitor& visitor) override {
             size_t num_unconstrained = 0;
 

--- a/libtatum/tatum/graph_walkers/SerialWalker.hpp
+++ b/libtatum/tatum/graph_walkers/SerialWalker.hpp
@@ -20,7 +20,20 @@ class SerialWalker : public TimingGraphWalker {
             //Do nothing, this walker only does full updates
         }
 
+        node_range modified_nodes_impl() const override {
+            return tatum::util::make_range(nodes_modified_.cbegin(), nodes_modified_.cend());
+        }
+
         void do_arrival_pre_traversal_impl(const TimingGraph& tg, const TimingConstraints& tc, GraphVisitor& visitor) override {
+            if (nodes_modified_.empty()) {
+                //This is a non-incremental updater so all nodes are always updated
+                auto nodes = tg.nodes();
+                nodes_modified_.reserve(nodes.size());
+                for (NodeId node : nodes) {
+                    nodes_modified_.push_back(node);
+                }
+            }
+
             size_t num_unconstrained = 0;
 
             LevelId first_level = *tg.levels().begin();
@@ -85,6 +98,7 @@ class SerialWalker : public TimingGraphWalker {
     private:
         size_t num_unconstrained_startpoints_ = 0;
         size_t num_unconstrained_endpoints_ = 0;
+        std::vector<NodeId> nodes_modified_;
 };
 
 } //namepsace

--- a/libtatum/tatum/graph_walkers/SerialWalker.hpp
+++ b/libtatum/tatum/graph_walkers/SerialWalker.hpp
@@ -16,6 +16,10 @@ class SerialWalker : public TimingGraphWalker {
             //Do nothing, this walker only does full updates
         }
 
+        void clear_invalidated_edges_impl() override {
+            //Do nothing, this walker only does full updates
+        }
+
         void do_arrival_pre_traversal_impl(const TimingGraph& tg, const TimingConstraints& tc, GraphVisitor& visitor) override {
             size_t num_unconstrained = 0;
 

--- a/libtatum/tatum/graph_walkers/TimingGraphWalker.hpp
+++ b/libtatum/tatum/graph_walkers/TimingGraphWalker.hpp
@@ -29,6 +29,10 @@ class TimingGraphWalker {
             invalidate_edge_impl(edge);
         }
 
+        void clear_invalidated_edges() {
+            clear_invalidated_edges_impl();
+        }
+
         ///Performs the arrival time pre-traversal
         ///\param tg The timing graph
         ///\param tc The timing constraints
@@ -113,8 +117,11 @@ class TimingGraphWalker {
         size_t num_unconstrained_endpoints() const { return num_unconstrained_endpoints_impl(); }
 
     protected:
-        ///Sub-class defined arrival time pre-traversal
+        ///Sub-class defined edge invalidation
         virtual void invalidate_edge_impl(const EdgeId edge) = 0;
+        //
+        ///Sub-class defined clearing of edge invalidation
+        virtual void clear_invalidated_edges_impl() = 0;
 
         ///Sub-class defined arrival time pre-traversal
         ///\param tg The timing graph

--- a/libtatum/tatum/graph_walkers/TimingGraphWalker.hpp
+++ b/libtatum/tatum/graph_walkers/TimingGraphWalker.hpp
@@ -3,8 +3,10 @@
 #include "tatum/TimingConstraintsFwd.hpp"
 #include "tatum/delay_calc/DelayCalculator.hpp"
 #include "tatum/graph_visitors/GraphVisitor.hpp"
+#include "tatum/util/tatum_range.hpp"
 #include <chrono>
 #include <map>
+#include <vector>
 
 namespace tatum {
 
@@ -22,6 +24,9 @@ namespace tatum {
  */
 class TimingGraphWalker {
     public:
+        typedef tatum::util::Range<std::vector<NodeId>::const_iterator> node_range;
+
+    public:
         virtual ~TimingGraphWalker() = default;
 
         ///Invalidates the specified timing graph edge (for incremental updates)
@@ -31,6 +36,10 @@ class TimingGraphWalker {
 
         void clear_invalidated_edges() {
             clear_invalidated_edges_impl();
+        }
+
+        node_range modified_nodes() const {
+            return modified_nodes_impl();
         }
 
         ///Performs the arrival time pre-traversal
@@ -119,9 +128,12 @@ class TimingGraphWalker {
     protected:
         ///Sub-class defined edge invalidation
         virtual void invalidate_edge_impl(const EdgeId edge) = 0;
-        //
+
         ///Sub-class defined clearing of edge invalidation
         virtual void clear_invalidated_edges_impl() = 0;
+
+        ///Sub-class defined clearing of edge invalidation
+        virtual node_range modified_nodes_impl() const = 0;
 
         ///Sub-class defined arrival time pre-traversal
         ///\param tg The timing graph

--- a/libtatum/tatum/graph_walkers/TimingGraphWalker.hpp
+++ b/libtatum/tatum/graph_walkers/TimingGraphWalker.hpp
@@ -24,6 +24,11 @@ class TimingGraphWalker {
     public:
         virtual ~TimingGraphWalker() = default;
 
+        ///Invalidates the specified timing graph edge (for incremental updates)
+        void invalidate_edge(const EdgeId edge) {
+            invalidate_edge_impl(edge);
+        }
+
         ///Performs the arrival time pre-traversal
         ///\param tg The timing graph
         ///\param tc The timing constraints
@@ -108,6 +113,9 @@ class TimingGraphWalker {
         size_t num_unconstrained_endpoints() const { return num_unconstrained_endpoints_impl(); }
 
     protected:
+        ///Sub-class defined arrival time pre-traversal
+        virtual void invalidate_edge_impl(const EdgeId edge) = 0;
+
         ///Sub-class defined arrival time pre-traversal
         ///\param tg The timing graph
         ///\param tc The timing constraints

--- a/libtatum/tatum/tags/TimingTag.hpp
+++ b/libtatum/tatum/tags/TimingTag.hpp
@@ -121,16 +121,18 @@ class TimingTag {
         ///If the arrival time is updated, meta-data is also updated from base_tag
         ///\param new_arr_time The arrival time to compare against
         ///\param base_tag The tag from which meta-data is copied
-        void max(const Time& new_time, const NodeId origin, const TimingTag& base_tag);
+        ///\returns true if the tag is modified, false otherwise
+        bool max(const Time& new_time, const NodeId origin, const TimingTag& base_tag);
 
         ///Updates the tag's arrival time if new_arr_time is smaller than the current arrival time.
         ///If the arrival time is updated, meta-data is also updated from base_tag
         ///\param new_arr_time The arrival time to compare against
         ///\param base_tag The tag from which meta-data is copied
-        void min(const Time& new_time, const NodeId origin, const TimingTag& base_tag);
+        ///\returns true if the tag is modified, false otherwise
+        bool min(const Time& new_time, const NodeId origin, const TimingTag& base_tag);
 
     private:
-        void update(const Time& new_time, const NodeId origin, const TimingTag& base_tag);
+        bool update(const Time& new_time, const NodeId origin, const TimingTag& base_tag);
 
         /*
          * Data

--- a/libtatum/tatum/tags/TimingTag.hpp
+++ b/libtatum/tatum/tags/TimingTag.hpp
@@ -95,6 +95,9 @@ class TimingTag {
 
         TagType type() const { return type_; }
 
+    public: //Utility
+        friend bool operator==(const TimingTag& lhs, const TimingTag& rhs);
+        friend bool operator!=(const TimingTag& lhs, const TimingTag& rhs);
     public: //Mutators
         ///\param new_time The new value set as the tag's time
         void set_time(const Time& new_time) { time_ = new_time; }

--- a/libtatum/tatum/tags/TimingTag.inl
+++ b/libtatum/tatum/tags/TimingTag.inl
@@ -35,7 +35,7 @@ inline TimingTag::TimingTag(const Time& time_val, NodeId origin, const TimingTag
     {}
 
 
-inline void TimingTag::update(const Time& new_time, const NodeId origin, const TimingTag& base_tag) {
+inline bool TimingTag::update(const Time& new_time, const NodeId origin, const TimingTag& base_tag) {
     TATUM_ASSERT(type() == base_tag.type()); //Type must be the same
 
     //Note that we check for a constant tag first, since we might 
@@ -57,25 +57,34 @@ inline void TimingTag::update(const Time& new_time, const NodeId origin, const T
     set_time(new_time);
     set_origin_node(origin);
 
+    return true; //Modified
 }
 
-inline void TimingTag::max(const Time& new_time, const NodeId origin, const TimingTag& base_tag) {
+inline bool TimingTag::max(const Time& new_time, const NodeId origin, const TimingTag& base_tag) {
+    bool modified = false;
+
     //Need to min with existing value
     if(!time().valid() || new_time > time()) {
         //New value is smaller, or no previous valid value existed
         //Update min
         
-        update(new_time, origin, base_tag);
+        modified |= update(new_time, origin, base_tag);
     }
+
+    return modified;
 }
 
-inline void TimingTag::min(const Time& new_time, const NodeId origin, const TimingTag& base_tag) {
+inline bool TimingTag::min(const Time& new_time, const NodeId origin, const TimingTag& base_tag) {
+    bool modified = false;
+
     //Need to min with existing value
     if(!time().valid() || new_time < time()) {
         //New value is smaller, or no previous valid value existed
         //Update min
-        update(new_time, origin, base_tag);
+        modified |= update(new_time, origin, base_tag);
     }
+
+    return modified;
 }
 
 inline std::ostream& operator<<(std::ostream& os, TagType type) {

--- a/libtatum/tatum/tags/TimingTag.inl
+++ b/libtatum/tatum/tags/TimingTag.inl
@@ -87,6 +87,15 @@ inline bool TimingTag::min(const Time& new_time, const NodeId origin, const Timi
     return modified;
 }
 
+inline bool operator==(const TimingTag& lhs, const TimingTag& rhs) {
+    return std::tie(lhs.time_, lhs.origin_node_, lhs.launch_clock_domain_, lhs.capture_clock_domain_, lhs.type_) 
+           == std::tie(rhs.time_, rhs.origin_node_, rhs.launch_clock_domain_, rhs.capture_clock_domain_, rhs.type_);
+}
+
+inline bool operator!=(const TimingTag& lhs, const TimingTag& rhs) {
+    return !(lhs == rhs);
+}
+
 inline std::ostream& operator<<(std::ostream& os, TagType type) {
     if(type == TagType::DATA_ARRIVAL) os << "DATA_ARRIVAL";
     else if(type == TagType::DATA_REQUIRED) os << "DATA_REQUIRED";

--- a/libtatum/tatum/tags/TimingTags.hpp
+++ b/libtatum/tatum/tags/TimingTags.hpp
@@ -40,6 +40,7 @@ class TimingTags {
         typedef Iterator<const TimingTag> const_iterator;
 
         typedef tatum::util::Range<const_iterator> tag_range;
+        typedef tatum::util::Range<iterator> mutable_tag_range;
 
     public:
 
@@ -64,6 +65,11 @@ class TimingTags {
         ///\returns A range of all tags matching type
         tag_range tags(const TagType type) const;
 
+        ///\returns A range of all tags
+        mutable_tag_range mutable_tags();
+
+        ///\returns A range of all tags matching type
+        mutable_tag_range mutable_tags(const TagType type);
 
         /*
          * Modifiers

--- a/libtatum/tatum/tags/TimingTags.hpp
+++ b/libtatum/tatum/tags/TimingTags.hpp
@@ -71,7 +71,7 @@ class TimingTags {
         ///Adds a TimingTag to the current set provided it has a valid clock domain
         ///\param tag_pool The pool memory allocator used to allocate the tag
         ///\param src_tag The source tag who is inserted. Note that the src_tag is copied when inserted (the original is unchanged)
-        void add_tag(const TimingTag& src_tag);
+        bool add_tag(const TimingTag& src_tag);
 
         /*
          * Operations
@@ -80,13 +80,13 @@ class TimingTags {
         ///\param new_time The new arrival time to compare against
         ///\param base_tag The associated metat-data for new_time
         ///\remark Finds (or creates) the tag with the same clock domain as base_tag and update the arrival time if new_time is larger
-        void max(const Time& new_time, const NodeId origin, const TimingTag& base_tag, bool arr_must_be_valid=false);
+        bool max(const Time& new_time, const NodeId origin, const TimingTag& base_tag, bool arr_must_be_valid=false);
 
         ///Updates the required time of this set of tags to be the minimum.
         ///\param new_time The new arrival time to compare against
         ///\param base_tag The associated metat-data for new_time
         ///\remark Finds (or creates) the tag with the same clock domain as base_tag and update the required time if new_time is smaller
-        void min(const Time& new_time, const NodeId origin, const TimingTag& base_tag, bool arr_must_be_valid=false);
+        bool min(const Time& new_time, const NodeId origin, const TimingTag& base_tag, bool arr_must_be_valid=false);
 
         ///Clears the tags in the current set
         void clear();

--- a/libtatum/tatum/tags/TimingTags.hpp
+++ b/libtatum/tatum/tags/TimingTags.hpp
@@ -73,6 +73,9 @@ class TimingTags {
         ///\param src_tag The source tag who is inserted. Note that the src_tag is copied when inserted (the original is unchanged)
         bool add_tag(const TimingTag& src_tag);
 
+        ///Like add_tag(), but sets the matching tag (instead of unconditionally adding it)
+        bool set_tag(const TimingTag& src_tag);
+
         /*
          * Operations
          */

--- a/libtatum/tatum/tags/TimingTags.inl
+++ b/libtatum/tatum/tags/TimingTags.inl
@@ -152,6 +152,32 @@ inline bool TimingTags::add_tag(const TimingTag& tag) {
     return true; //Was modified
 }
 
+inline bool TimingTags::set_tag(const TimingTag& tag) {
+    bool modified = false;
+    auto bool_iter = find_matching_tag(tag, false);
+
+    bool valid = bool_iter.first;
+    TATUM_ASSERT_SAFE(valid);
+
+    auto iter = bool_iter.second;
+    if(iter == end(tag.type())) {
+        //An exact match was not found
+
+        //First time we've seen this domain
+        modified |= add_tag(tag);
+    } else { //Found an exact match to launch/capture
+        if (iter->time() != tag.time() || iter->origin_node() != tag.origin_node()) {
+            //Other attributes differ, update to new values
+            *iter = tag;
+            modified |= true;
+        } else { //Tag is identical
+            TATUM_ASSERT_SAFE(*iter == tag);
+        }
+    }
+
+    return modified;
+}
+
 inline bool TimingTags::max(const Time& new_time, const NodeId origin, const TimingTag& base_tag, bool arr_must_be_valid) {
     bool modified = false;
     auto bool_iter = find_matching_tag(base_tag, arr_must_be_valid);

--- a/libtatum/tatum/tags/TimingTags.inl
+++ b/libtatum/tatum/tags/TimingTags.inl
@@ -136,7 +136,7 @@ inline TimingTags::tag_range TimingTags::tags(const TagType type) const {
 }
 
 //Modifiers
-inline void TimingTags::add_tag(const TimingTag& tag) {
+inline bool TimingTags::add_tag(const TimingTag& tag) {
     //Find the position to insert this tag
     //
     //We keep tags of the same type together.
@@ -148,9 +148,12 @@ inline void TimingTags::add_tag(const TimingTag& tag) {
     //Insert the tag before the upper bound position
     // This ensures tags_ is always in sorted order
     insert(iter, tag);
+
+    return true; //Was modified
 }
 
-inline void TimingTags::max(const Time& new_time, const NodeId origin, const TimingTag& base_tag, bool arr_must_be_valid) {
+inline bool TimingTags::max(const Time& new_time, const NodeId origin, const TimingTag& base_tag, bool arr_must_be_valid) {
+    bool modified = false;
     auto bool_iter = find_matching_tag(base_tag, arr_must_be_valid);
 
     bool valid = bool_iter.first;
@@ -161,14 +164,18 @@ inline void TimingTags::max(const Time& new_time, const NodeId origin, const Tim
 
             //First time we've seen this domain
             TimingTag tag = TimingTag(new_time, origin, base_tag);
-            add_tag(tag);
+            modified |= add_tag(tag);
         } else {
-            iter->max(new_time, origin, base_tag);
+            modified |= iter->max(new_time, origin, base_tag);
         }
     }
+
+    return modified;
 }
 
-inline void TimingTags::min(const Time& new_time, const NodeId origin, const TimingTag& base_tag, bool arr_must_be_valid) {
+inline bool TimingTags::min(const Time& new_time, const NodeId origin, const TimingTag& base_tag, bool arr_must_be_valid) {
+    bool modified = false;
+
     auto bool_iter = find_matching_tag(base_tag, arr_must_be_valid);
 
     bool valid = bool_iter.first;
@@ -179,11 +186,12 @@ inline void TimingTags::min(const Time& new_time, const NodeId origin, const Tim
 
             //First time we've seen this domain
             TimingTag tag = TimingTag(new_time, origin, base_tag);
-            add_tag(tag);
+            modified |= add_tag(tag);
         } else {
-            iter->min(new_time, origin, base_tag);
+            modified |= iter->min(new_time, origin, base_tag);
         }
     }
+    return modified;
 }
 
 inline void TimingTags::clear() {

--- a/libtatum/tatum/tags/TimingTags.inl
+++ b/libtatum/tatum/tags/TimingTags.inl
@@ -135,6 +135,14 @@ inline TimingTags::tag_range TimingTags::tags(const TagType type) const {
     return tatum::util::make_range(begin(type), end(type));
 }
 
+inline TimingTags::mutable_tag_range TimingTags::mutable_tags() {
+    return tatum::util::make_range(begin(), end());
+}
+
+inline TimingTags::mutable_tag_range TimingTags::mutable_tags(const TagType type) {
+    return tatum::util::make_range(begin(type), end(type));
+}
+
 //Modifiers
 inline bool TimingTags::add_tag(const TimingTag& tag) {
     //Find the position to insert this tag

--- a/libtatum/tatum/util/tatum_assert.cpp
+++ b/libtatum/tatum/util/tatum_assert.cpp
@@ -1,0 +1,23 @@
+#include "tatum_assert.hpp"
+
+#include <cstdio>  //fprintf, stderr
+#include <cstdlib> //abort
+
+namespace tatum {
+namespace assert {
+
+void handle_assert(const char* expr, const char* file, unsigned int line, const char* function, const char* msg) {
+    fprintf(stderr, "%s:%d", file, line);
+    if (function) {
+        fprintf(stderr, " %s:", function);
+    }
+    fprintf(stderr, " Assertion '%s' failed", expr);
+    if (msg) {
+        fprintf(stderr, " (%s)", msg);
+    }
+    fprintf(stderr, ".\n");
+    std::abort();
+}
+
+} // namespace assert
+} // namespace tatum

--- a/libtatum/tatum/util/tatum_assert.hpp
+++ b/libtatum/tatum/util/tatum_assert.hpp
@@ -1,79 +1,108 @@
 #ifndef TATUM_ASSERT_H
 #define TATUM_ASSERT_H
-#include <cstdio> //fprintf, stderr
-#include <cstdlib> //abort
 /*
  * The header defines useful assertion macros for TATUM projects.
  *
  * Three types of assertions are defined:
- *      TATUM_ASSERT_OPT  - low overhead assertions that should always be enabled
- *      TATUM_ASSERT      - medium overhead assertions that may be enabled
- *      TATUM_ASSERT_SAFE - high overhead assertions typically enabled only for debugging
+ *      TATUM_ASSERT_OPT   - low overhead assertions that should always be enabled
+ *      TATUM_ASSERT       - medium overhead assertions that are usually be enabled
+ *      TATUM_ASSERT_SAFE  - high overhead assertions typically enabled only for debugging
+ *      TATUM_ASSERT_DEBUG - very high overhead assertions typically enabled only for extreme debugging
  * Each of the above assertions also have a *_MSG variants (e.g. TATUM_ASSERT_MSG(expr, msg))
- * which takes an additional argument specifying additional message text to be shown when 
- * the assertion fails.
+ * which takes an additional argument specifying additional message text to be shown.
+ * By convention the message should state the condition *being checked* (and not the failure condition),
+ * since that the condition failed is obvious from the assertion failure itself.
  *
  * The macro TATUM_ASSERT_LEVEL specifies the level of assertion checking desired:
  *
+ *      TATUM_ASSERT_LEVEL == 4: TATUM_ASSERT_OPT, TATUM_ASSERT, TATUM_ASSERT_SAFE, TATUM_ASSERT_DEBUG enabled
  *      TATUM_ASSERT_LEVEL == 3: TATUM_ASSERT_OPT, TATUM_ASSERT, TATUM_ASSERT_SAFE enabled
  *      TATUM_ASSERT_LEVEL == 2: TATUM_ASSERT_OPT, TATUM_ASSERT enabled
  *      TATUM_ASSERT_LEVEL == 1: TATUM_ASSERT_OPT enabled
  *      TATUM_ASSERT_LEVEL == 0: No assertion checking enabled
- * Note that an assertion levels beyond 3 are currently treated the same as level 3 
+ * Note that an assertion levels beyond 4 are currently treated the same as level 4
  */
 
 //Set a default assertion level if none is specified
 #ifndef TATUM_ASSERT_LEVEL
-# define TATUM_ASSERT_LEVEL 2
+#    define TATUM_ASSERT_LEVEL 2
 #endif
 
 //Enable the assertions based on the specified level
+#if TATUM_ASSERT_LEVEL >= 4
+#    define TATUM_ASSERT_DEBUG_ENABLED
+#endif
+
 #if TATUM_ASSERT_LEVEL >= 3
-# define TATUM_ASSERT_SAFE_ENABLED
+#    define TATUM_ASSERT_SAFE_ENABLED
 #endif
 
 #if TATUM_ASSERT_LEVEL >= 2
-#define TATUM_ASSERT_ENABLED
+#    define TATUM_ASSERT_ENABLED
 #endif
 
 #if TATUM_ASSERT_LEVEL >= 1
-# define TATUM_ASSERT_OPT_ENABLED
+#    define TATUM_ASSERT_OPT_ENABLED
 #endif
 
 //Define the user assertion macros
-#ifdef TATUM_ASSERT_SAFE_ENABLED
-# define TATUM_ASSERT_SAFE(expr) TATUM_ASSERT_IMPL(expr, nullptr)
-# define TATUM_ASSERT_SAFE_MSG(expr, msg) TATUM_ASSERT_IMPL(expr, msg)
+#ifdef TATUM_ASSERT_DEBUG_ENABLED
+#    define TATUM_ASSERT_DEBUG(expr) TATUM_ASSERT_IMPL(expr, nullptr)
+#    define TATUM_ASSERT_DEBUG_MSG(expr, msg) TATUM_ASSERT_IMPL(expr, msg)
 #else
-# define TATUM_ASSERT_SAFE(expr) static_cast<void>(0)
-# define TATUM_ASSERT_SAFE_MSG(expr, msg) static_cast<void>(0)
+#    define TATUM_ASSERT_DEBUG(expr) TATUM_ASSERT_IMPL_NOP(expr, nullptr)
+#    define TATUM_ASSERT_DEBUG_MSG(expr, msg) TATUM_ASSERT_IMPL_NOP(expr, msg)
+#endif
+
+#ifdef TATUM_ASSERT_SAFE_ENABLED
+#    define TATUM_ASSERT_SAFE(expr) TATUM_ASSERT_IMPL(expr, nullptr)
+#    define TATUM_ASSERT_SAFE_MSG(expr, msg) TATUM_ASSERT_IMPL(expr, msg)
+#else
+#    define TATUM_ASSERT_SAFE(expr) TATUM_ASSERT_IMPL_NOP(expr, nullptr)
+#    define TATUM_ASSERT_SAFE_MSG(expr, msg) TATUM_ASSERT_IMPL_NOP(expr, msg)
 #endif
 
 #ifdef TATUM_ASSERT_ENABLED
-# define TATUM_ASSERT(expr) TATUM_ASSERT_IMPL(expr, nullptr)
-# define TATUM_ASSERT_MSG(expr, msg) TATUM_ASSERT_IMPL(expr, msg)
+#    define TATUM_ASSERT(expr) TATUM_ASSERT_IMPL(expr, nullptr)
+#    define TATUM_ASSERT_MSG(expr, msg) TATUM_ASSERT_IMPL(expr, msg)
 #else
-# define TATUM_ASSERT(expr) static_cast<void>(0)
-# define TATUM_ASSERT_MSG(expr, msg) static_cast<void>(0)
+#    define TATUM_ASSERT(expr) TATUM_ASSERT_IMPL_NOP(expr, nullptr)
+#    define TATUM_ASSERT_MSG(expr, msg) TATUM_ASSERT_IMPL_NOP(expr, msg)
 #endif
 
 #ifdef TATUM_ASSERT_OPT_ENABLED
-# define TATUM_ASSERT_OPT(expr) TATUM_ASSERT_IMPL(expr, nullptr)
-# define TATUM_ASSERT_OPT_MSG(expr, msg) TATUM_ASSERT_IMPL(expr, msg)
+#    define TATUM_ASSERT_OPT(expr) TATUM_ASSERT_IMPL(expr, nullptr)
+#    define TATUM_ASSERT_OPT_MSG(expr, msg) TATUM_ASSERT_IMPL(expr, msg)
 #else
-# define TATUM_ASSERT_OPT(expr) static_cast<void>(0)
-# define TATUM_ASSERT_OPT_MSG(expr, msg) static_cast<void>(0)
+#    define TATUM_ASSERT_OPT(expr) TATUM_ASSERT_IMPL_NOP(expr, nullptr)
+#    define TATUM_ASSERT_OPT_MSG(expr, msg) TATUM_ASSERT_IMPL_NOP(expr, msg)
 #endif
-
 
 //Define the assertion implementation macro
 // We wrap the check in a do {} while() to ensure the function-like
 // macro can be always be followed by a ';'
-#define TATUM_ASSERT_IMPL(expr, msg) do {\
-        if(!(expr)) { \
-            tatum::util::Assert::handle_assert(#expr, __FILE__, __LINE__, TATUM_ASSERT_FUNCTION, msg); \
-        } \
-    } while(false)
+#define TATUM_ASSERT_IMPL(expr, msg)                                                           \
+    do {                                                                                     \
+        if (!(expr)) {                                                                       \
+            tatum::assert::handle_assert(#expr, __FILE__, __LINE__, TATUM_ASSERT_FUNCTION, msg); \
+        }                                                                                    \
+    } while (false)
+
+//Define the no-op assertion implementation macro
+// We wrap the check in a do {} while() to ensure the function-like
+// macro can be always be followed by a ';'
+//
+// Note that to avoid 'unused' variable warnings when assertions are
+// disabled, we pass the expr and msg to sizeof(). We use sizeof specifically
+// since it accepts expressions, and the C++ standard gaurentees sizeof's arguments
+// are never evaluated (ensuring any expensive expressions are not evaluated when
+// assertions are disabled). To avoid warnings about the unused result of sizeof()
+// we cast it to void.
+#define TATUM_ASSERT_IMPL_NOP(expr, msg)   \
+    do {                                 \
+        static_cast<void>(sizeof(expr)); \
+        static_cast<void>(sizeof(msg));  \
+    } while (false)
 
 //Figure out what macro to use to get the name of the current function
 // We default to __func__ which is defined in C99
@@ -82,31 +111,26 @@
 // information, so we prefer to use it if possible
 #define TATUM_ASSERT_FUNCTION __func__
 #ifdef __GNUC__
-# ifdef __GNUC_MINOR__
-#  if __GNUC__ >= 2 && __GNUC_MINOR__ > 6
-#   undef TATUM_ASSERT_FUNCTION
-#   define TATUM_ASSERT_FUNCTION __PRETTY_FUNCTION__
-#  endif
-# endif
+#    ifdef __GNUC_MINOR__
+#        if __GNUC__ >= 2 && __GNUC_MINOR__ > 6
+#            undef TATUM_ASSERT_FUNCTION
+#            define TATUM_ASSERT_FUNCTION __PRETTY_FUNCTION__
+#        endif
+#    endif
 #endif
 
-namespace tatum { namespace util {
-    class Assert {
-        
-        public:
-            static void handle_assert(const char* expr, const char* file, unsigned int line, const char* function, const char* msg) {
-                fprintf(stderr, "%s:%d", file, line);
-                if(function) {
-                    fprintf(stderr, " %s:", function);
-                }
-                fprintf(stderr, " Assertion '%s' failed", expr);
-                if(msg) {
-                    fprintf(stderr, " (%s)", msg);
-                }
-                fprintf(stderr, ".\n");
-                std::abort();
-            }
-    };
-}} //namespace
+namespace tatum {
+namespace assert {
+//Assertion handling routine
+//
+//Note that we mark the routine with the standard C++11
+//attribute 'noreturn' which tells the compiler this
+//function will never return. This should ensure the
+//compiler won't warn about detected conditions such as
+//dead-code or potential null pointer dereferences
+//which are gaurded against by assertions.
+[[noreturn]] void handle_assert(const char* expr, const char* file, unsigned int line, const char* function, const char* msg);
+} // namespace assert
+} // namespace tatum
 
 #endif //TATUM_ASSERT_H

--- a/scripts/reg_test.py
+++ b/scripts/reg_test.py
@@ -53,6 +53,11 @@ def parse_args():
                         type=int,
                         default=3)
 
+    parser.add_argument("--tatum_nserial_incr",
+                        help="How serial incremental runs tatum should perform per test. (Default: %(default)s)",
+                        type=int,
+                        default=3)
+
     parser.add_argument("--tatum_nparallel",
                         help="How parallel runs tatum should perform per test. (Default: %(default)s)",
                         type=int,
@@ -112,6 +117,7 @@ def run_single_test(args, work_dir, test_file):
     cmd += ['--verify', "1"]
 
     cmd += ['--num_serial', str(args.tatum_nserial)]
+    cmd += ['--num_serial_incr', str(args.tatum_nserial_incr)]
     cmd += ['--num_parallel', str(args.tatum_nparallel)]
 
     if args.tatum_nworkers:

--- a/tatum_test/CMakeLists.txt
+++ b/tatum_test/CMakeLists.txt
@@ -53,7 +53,7 @@ target_link_libraries(tatum_test libtatum libtatumparse)
 if(TATUM_TEST_ENABLE_VTUNE_PROFILE)
     target_include_directories(tatum_test PRIVATE /opt/intel/vtune_amplifier_xe/include)
     target_link_libraries(tatum_test /opt/intel/vtune_amplifier_xe/lib64/libittnotify.a ${CMAKE_DL_LIBS})
-    target_compile_definitions(tatum_test PRIVATE TATUM_TEST_PROFILE_VTUNE=1)
+    target_compile_definitions(tatum_test PRIVATE TATUM_TEST_PROFILE_VTUNE)
     target_compile_options(tatum_test PUBLIC -g)
 endif()
 
@@ -62,6 +62,6 @@ if(TATUM_TEST_ENABLE_CALLGRIND_PROFILE)
     #To selectively profile using callgrind:
     #  valgrind --tool=callgrind --collect-atstart=no --instr-atstart=no --cache-sim=yes --cacheuse=yes ./command
 
-    target_compile_definitions(tatum_test PRIVATE TATUM_TEST_PROFILE_CALLGRIND=1)
+    target_compile_definitions(tatum_test PRIVATE TATUM_TEST_PROFILE_CALLGRIND)
     target_compile_options(tatum_test PUBLIC -g)
 endif()

--- a/tatum_test/main.cpp
+++ b/tatum_test/main.cpp
@@ -76,7 +76,7 @@ struct Args {
     size_t print_sizes = 0;
 
     //Verify results match reference
-    size_t verify = 0;
+    size_t verify = 1;
 
     //Print reports
     size_t report = 1;

--- a/tatum_test/main.cpp
+++ b/tatum_test/main.cpp
@@ -512,7 +512,11 @@ int main(int argc, char** argv) {
             cout << "Running SerialIncr Analysis " << args.num_serial_incr_runs << " times" << endl;
 
             //Analyze
+#if 0
             serial_incr_prof_data = profile(args.num_serial_incr_runs, serial_incr_analyzer);
+#else
+            serial_incr_prof_data = profile_rand_incr(args.num_serial_incr_runs, serial_incr_analyzer, *delay_calculator, *timing_graph);
+#endif
 
             //Verify
             clock_gettime(CLOCK_MONOTONIC, &verify_start);

--- a/tatum_test/main.cpp
+++ b/tatum_test/main.cpp
@@ -515,7 +515,7 @@ int main(int argc, char** argv) {
 #if 0
             serial_incr_prof_data = profile(args.num_serial_incr_runs, serial_incr_analyzer);
 #else
-            serial_incr_prof_data = profile_rand_incr(args.num_serial_incr_runs, serial_incr_analyzer, serial_analyzer, *delay_calculator, *timing_graph, *timing_constraints);
+            serial_incr_prof_data = profile_rand_incr(args.num_serial_incr_runs, 0.01, serial_incr_analyzer, serial_analyzer, *delay_calculator, *timing_graph);
 #endif
 
             //Verify

--- a/tatum_test/main.cpp
+++ b/tatum_test/main.cpp
@@ -592,6 +592,10 @@ int main(int argc, char** argv) {
         cout << "  " << cpd.launch_domain() << " -> " << cpd.capture_domain() << ": " << std::scientific << cpd.delay() << "\n";
     }
 
+    if (exit_code) {
+        cout << "FAILED!\n";
+    }
+
     clock_gettime(CLOCK_MONOTONIC, &prog_end);
 
     cout << endl << "Total time: " << tatum::time_sec(prog_start, prog_end) << " sec" << endl;

--- a/tatum_test/main.cpp
+++ b/tatum_test/main.cpp
@@ -515,7 +515,7 @@ int main(int argc, char** argv) {
 #if 0
             serial_incr_prof_data = profile(args.num_serial_incr_runs, serial_incr_analyzer);
 #else
-            serial_incr_prof_data = profile_rand_incr(args.num_serial_incr_runs, serial_incr_analyzer, *delay_calculator, *timing_graph);
+            serial_incr_prof_data = profile_rand_incr(args.num_serial_incr_runs, serial_incr_analyzer, serial_analyzer, *delay_calculator, *timing_graph, *timing_constraints);
 #endif
 
             //Verify

--- a/tatum_test/main.cpp
+++ b/tatum_test/main.cpp
@@ -502,7 +502,7 @@ int main(int argc, char** argv) {
         size_t parallel_tags_verified = 0;
         std::map<std::string,std::vector<double>> parallel_prof_data;
         {
-            cout << "Running Parrallel Analysis " << args.num_parallel_runs << " times" << endl;
+            cout << "Running Parallel Analysis " << args.num_parallel_runs << " times" << endl;
 
             //Analyze
             parallel_prof_data = profile(args.num_parallel_runs, parallel_analyzer);

--- a/tatum_test/main.cpp
+++ b/tatum_test/main.cpp
@@ -483,11 +483,11 @@ int main(int argc, char** argv) {
         cout << " (" << std::setprecision(2) << median(serial_prof_data["update_slack_sec"])/median(serial_prof_data["analysis_sec"]) << ")" << endl;
 
         cout << "Verifying Serial Analysis took: " << serial_verify_time << " sec" << endl;
-        if(serial_tags_verified != golden_reference->num_tags() && serial_tags_verified != golden_reference->num_tags() / 2) {
-            //Potentially alow / 2 for setup only analysis from setup/hold golden
-            cout << "WARNING: Expected tags (" << golden_reference->num_tags() << ") differs from tags checked (" << serial_tags_verified << ") , verification may not have occured!" << endl;
-        } else {
+        if(serial_tags_verified == golden_reference->num_tags() || serial_tags_verified == golden_reference->num_tags() / 2) {
+            //Potentially allow / 2 for setup only analysis from setup/hold golden
             cout << "\tVerified " << serial_tags_verified << " tags (expected " << golden_reference->num_tags() << " or " << golden_reference->num_tags()/2 << ") accross " << timing_graph->nodes().size() << " nodes" << endl;
+        } else {
+            cout << "WARNING: Expected tags (" << golden_reference->num_tags() << ") differs from tags checked (" << serial_tags_verified << ") , verification may not have occured!" << endl;
         }
         cout << endl;
         cout << endl << "Net Serial Analysis elapsed time: " << serial_analyzer->get_profiling_data("total_analysis_sec") << " sec over " << serial_analyzer->get_profiling_data("num_full_updates") << " full updates" << endl;
@@ -526,7 +526,28 @@ int main(int argc, char** argv) {
                 if(!res.second) {
                     cout << "Verification failed!\n";
                     exit_code = 1;
+
+
                 }
+            }
+
+            std::vector<NodeId> nodes;
+            if (args.debug_dot_node == -1) {
+                //Pass
+            } else if (args.debug_dot_node < -1) {
+                auto tg_nodes = timing_graph->nodes();
+                nodes = std::vector<NodeId>(tg_nodes.begin(), tg_nodes.end());
+            } else if (args.debug_dot_node >= 0) {
+                nodes = find_transitively_connected_nodes(*timing_graph, {NodeId(args.debug_dot_node)});
+            }
+            if (args.debug_dot_node != -1) {
+                auto dot_writer = make_graphviz_dot_writer(*timing_graph, *delay_calculator);
+                dot_writer.set_nodes_to_dump(nodes);
+
+                std::shared_ptr<tatum::SetupTimingAnalyzer> debug_setup_analyzer = std::dynamic_pointer_cast<tatum::SetupTimingAnalyzer>(serial_incr_analyzer);
+                dot_writer.write_dot_file("debug_tg_setup_annotated.dot", *debug_setup_analyzer);
+                std::shared_ptr<tatum::HoldTimingAnalyzer> debug_hold_analyzer = std::dynamic_pointer_cast<tatum::HoldTimingAnalyzer>(serial_incr_analyzer);
+                dot_writer.write_dot_file("debug_tg_hold_annotated.dot", *debug_setup_analyzer);
             }
 
             clock_gettime(CLOCK_MONOTONIC, &verify_end);
@@ -561,11 +582,11 @@ int main(int argc, char** argv) {
             cout << " (" << std::setprecision(2) << median(serial_incr_prof_data["update_slack_sec"])/median(serial_incr_prof_data["analysis_sec"]) << ")" << endl;
 
             cout << "Verifying SerialIncr Analysis took: " <<  serial_incr_verify_time<< " sec" << endl;
-            if(serial_incr_tags_verified != golden_reference->num_tags() && serial_incr_tags_verified != golden_reference->num_tags()/2) {
-                //Potentially alow / 2 for setup only analysis from setup/hold golden
-                cout << "WARNING: Expected tags (" << golden_reference->num_tags() << ") differs from tags checked (" << serial_tags_verified << ") , verification may not have occured!" << endl;
-            } else {
+            if(serial_incr_tags_verified == golden_reference->num_tags() || serial_incr_tags_verified == golden_reference->num_tags()/2) {
+                //Potentially allow / 2 for setup only analysis from setup/hold golden
                 cout << "\tVerified " << serial_tags_verified << " tags (expected " << golden_reference->num_tags() << " or " << golden_reference->num_tags()/2 << ") accross " << timing_graph->nodes().size() << " nodes" << endl;
+            } else {
+                cout << "WARNING: Expected tags (" << golden_reference->num_tags() << ") differs from tags checked (" << serial_incr_tags_verified << ") , verification may not have occured!" << endl;
             }
         }
         cout << endl;
@@ -644,11 +665,11 @@ int main(int argc, char** argv) {
             cout << " (" << std::setprecision(2) << median(parallel_prof_data["update_slack_sec"])/median(parallel_prof_data["analysis_sec"]) << ")" << endl;
 
             cout << "Verifying Parallel Analysis took: " <<  parallel_verify_time<< " sec" << endl;
-            if(parallel_tags_verified != golden_reference->num_tags() && parallel_tags_verified != golden_reference->num_tags()/2) {
-                //Potentially alow / 2 for setup only analysis from setup/hold golden
-                cout << "WARNING: Expected tags (" << golden_reference->num_tags() << ") differs from tags checked (" << serial_tags_verified << ") , verification may not have occured!" << endl;
-            } else {
+            if(parallel_tags_verified == golden_reference->num_tags() || parallel_tags_verified == golden_reference->num_tags()/2) {
+                //Potentially allow / 2 for setup only analysis from setup/hold golden
                 cout << "\tVerified " << serial_tags_verified << " tags (expected " << golden_reference->num_tags() << " or " << golden_reference->num_tags()/2 << ") accross " << timing_graph->nodes().size() << " nodes" << endl;
+            } else {
+                cout << "WARNING: Expected tags (" << golden_reference->num_tags() << ") differs from tags checked (" << parallel_tags_verified << ") , verification may not have occured!" << endl;
             }
         }
         cout << endl;

--- a/tatum_test/main.cpp
+++ b/tatum_test/main.cpp
@@ -63,6 +63,10 @@ struct Args {
     //Number of serial incremental runs to perform
     size_t num_serial_incr_runs = 10;
 
+    //What percentange of edges have delay changes
+    //for each serial incremental run
+    float edge_change_prob = 0.01;
+
     //Number of parallel runs to perform
     size_t num_parallel_runs = 30;
 
@@ -115,6 +119,8 @@ void usage(std::string prog) {
     cout << "                                               (default " << default_args.num_serial_incr_runs << ")\n";
     cout << "    --num_parallel NUM_PARALLEL_RUNS:          Number of serial runs to perform.\n";
     cout << "                                               (default " << default_args.num_parallel_runs << ")\n";
+    cout << "    --edge_change_prob EDGE_CHANGE_PROB:       Probability of an edge delay changing in a serial incremental run\n";
+    cout << "                                               (default " << default_args.edge_change_prob << ")\n";
     cout << "    --unit_delay UNIT_DELAY:                   Use specified unit delay for all edges.\n";
     cout << "                                               0 uses delay model from input.\n";
     cout << "                                               (default " << default_args.unit_delay << ")\n";
@@ -187,6 +193,8 @@ Args parse_args(int argc, char** argv) {
                     args.num_serial_incr_runs = arg_val;
                 } else if (argv[i] == std::string("--num_parallel")) { 
                     args.num_parallel_runs = arg_val;
+                } else if (argv[i] == std::string("--edge_change_prob")) { 
+                    args.edge_change_prob = arg_val;
                 } else if (argv[i] == std::string("--unit_delay")) { 
                     args.unit_delay = arg_val;
                 } else if (argv[i] == std::string("--opt_graph_layout")) { 
@@ -515,7 +523,7 @@ int main(int argc, char** argv) {
 #if 0
             serial_incr_prof_data = profile(args.num_serial_incr_runs, serial_incr_analyzer);
 #else
-            serial_incr_prof_data = profile_rand_incr(args.num_serial_incr_runs, 0.01, serial_incr_analyzer, serial_analyzer, *delay_calculator, *timing_graph);
+            serial_incr_prof_data = profile_rand_incr(args.num_serial_incr_runs, args.edge_change_prob, serial_incr_analyzer, serial_analyzer, *delay_calculator, *timing_graph);
 #endif
 
             //Verify

--- a/tatum_test/main.cpp
+++ b/tatum_test/main.cpp
@@ -60,6 +60,9 @@ struct Args {
     //Number of serial runs to perform
     size_t num_serial_runs = 10;
 
+    //Number of serial incremental runs to perform
+    size_t num_serial_incr_runs = 10;
+
     //Number of parallel runs to perform
     size_t num_parallel_runs = 30;
 
@@ -103,38 +106,40 @@ void usage(std::string prog) {
     cout << "    tg_file:                      The input file (or '-' for stdin)\n";
     cout << "\n";
     cout << "  Options:\n";
-    cout << "    --num_workers NUM_WORKERS:        Number of parallel workers.\n";
-    cout << "                                      0 implies machine concurrency.\n";
-    cout << "                                      (default " << default_args.num_workers << ")\n";
-    cout << "    --num_serial NUM_SERIAL_RUNS:     Number of serial runs to perform.\n";
-    cout << "                                      (default " << default_args.num_serial_runs << ")\n";
-    cout << "    --num_parallel NUM_PARALLEL_RUNS: Number of serial runs to perform.\n";
-    cout << "                                      (default " << default_args.num_parallel_runs << ")\n";
-    cout << "    --unit_delay UNIT_DELAY:          Use specified unit delay for all edges.\n";
-    cout << "                                      0 uses delay model from input.\n";
-    cout << "                                      (default " << default_args.unit_delay << ")\n";
-    cout << "    --write_echo WRITE_ECHO:          Write an echo file of restuls.\n";
-    cout << "                                      empty implies no, non-empty implies write to specified file.\n";
-    cout << "                                      (default " << default_args.write_echo << ")\n";
-    cout << "    --opt_graph_layout OPT_LAYOUT:    Optimize graph layout.\n";
-    cout << "                                      0 implies no, non-zero implies yes.\n";
-    cout << "                                      (default " << default_args.opt_graph_layout << ")\n";
-    cout << "    --print_sizes PRINT_SIZES:        Print various data structure sizes.\n";
-    cout << "                                      0 implies no, non-zero implies yes.\n";
-    cout << "                                      (default " << default_args.print_sizes << ")\n";
-    cout << "    --report REPORT:                  Generate various reports.\n";
-    cout << "                                      0 implies no, non-zero implies yes.\n";
-    cout << "                                      (default " << default_args.report << ")\n";
-    cout << "    --verify VERIFY:                  Verify calculated results match reference.\n";
-    cout << "                                      0 implies no, non-zero implies yes.\n";
-    cout << "                                      (default " << default_args.verify << ")\n";
-    cout << "    --debug_dot_node NODEID:          Specifies the timing graph node node whose transitive\n";
-    cout << "                                      connections are dumped to the .dot file (useful for debugging).\n";
-    cout << "                                      Values < -1 dump the entire graph,\n";
-    cout << "                                      Values == -1 do not dump dot file,\n";
-    cout << "                                      Values >= 0 dump the transitive connections of\n";
-    cout << "                                      the matching node.\n";
-    cout << "                                      (default " << default_args.debug_dot_node << ")\n";
+    cout << "    --num_workers NUM_WORKERS:                 Number of parallel workers.\n";
+    cout << "                                               0 implies machine concurrency.\n";
+    cout << "                                               (default " << default_args.num_workers << ")\n";
+    cout << "    --num_serial NUM_SERIAL_RUNS:              Number of serial runs to perform.\n";
+    cout << "                                               (default " << default_args.num_serial_runs << ")\n";
+    cout << "    --num_serial_incr NUM_SERIAL_INCR_RUNS:    Number of serial incremental runs to perform.\n";
+    cout << "                                               (default " << default_args.num_serial_incr_runs << ")\n";
+    cout << "    --num_parallel NUM_PARALLEL_RUNS:          Number of serial runs to perform.\n";
+    cout << "                                               (default " << default_args.num_parallel_runs << ")\n";
+    cout << "    --unit_delay UNIT_DELAY:                   Use specified unit delay for all edges.\n";
+    cout << "                                               0 uses delay model from input.\n";
+    cout << "                                               (default " << default_args.unit_delay << ")\n";
+    cout << "    --write_echo WRITE_ECHO:                   Write an echo file of restuls.\n";
+    cout << "                                               empty implies no, non-empty implies write to specified file.\n";
+    cout << "                                               (default " << default_args.write_echo << ")\n";
+    cout << "    --opt_graph_layout OPT_LAYOUT:             Optimize graph layout.\n";
+    cout << "                                               0 implies no, non-zero implies yes.\n";
+    cout << "                                               (default " << default_args.opt_graph_layout << ")\n";
+    cout << "    --print_sizes PRINT_SIZES:                 Print various data structure sizes.\n";
+    cout << "                                               0 implies no, non-zero implies yes.\n";
+    cout << "                                               (default " << default_args.print_sizes << ")\n";
+    cout << "    --report REPORT:                           Generate various reports.\n";
+    cout << "                                               0 implies no, non-zero implies yes.\n";
+    cout << "                                               (default " << default_args.report << ")\n";
+    cout << "    --verify VERIFY:                           Verify calculated results match reference.\n";
+    cout << "                                               0 implies no, non-zero implies yes.\n";
+    cout << "                                               (default " << default_args.verify << ")\n";
+    cout << "    --debug_dot_node NODEID:                   Specifies the timing graph node node whose transitive\n";
+    cout << "                                               connections are dumped to the .dot file (useful for debugging).\n";
+    cout << "                                               Values < -1 dump the entire graph,\n";
+    cout << "                                               Values == -1 do not dump dot file,\n";
+    cout << "                                               Values >= 0 dump the transitive connections of\n";
+    cout << "                                               the matching node.\n";
+    cout << "                                               (default " << default_args.debug_dot_node << ")\n";
 }
 
 void cmd_error(std::string prog, std::string msg) {
@@ -178,6 +183,8 @@ Args parse_args(int argc, char** argv) {
                     args.num_workers = arg_val;
                 } else if (argv[i] == std::string("--num_serial")) { 
                     args.num_serial_runs = arg_val;
+                } else if (argv[i] == std::string("--num_serial_incr")) { 
+                    args.num_serial_incr_runs = arg_val;
                 } else if (argv[i] == std::string("--num_parallel")) { 
                     args.num_parallel_runs = arg_val;
                 } else if (argv[i] == std::string("--unit_delay")) { 
@@ -492,6 +499,89 @@ int main(int argc, char** argv) {
     }
 
     std::cout << endl;
+
+    if (args.num_serial_incr_runs) {
+        std::shared_ptr<tatum::TimingAnalyzer> serial_incr_analyzer = tatum::AnalyzerFactory<tatum::SetupHoldAnalysis,tatum::SerialIncrWalker>::make(*timing_graph, *timing_constraints, *delay_calculator);
+        auto serial_incr_setup_analyzer = std::dynamic_pointer_cast<tatum::SetupTimingAnalyzer>(serial_incr_analyzer);
+        auto serial_incr_hold_analyzer = std::dynamic_pointer_cast<tatum::HoldTimingAnalyzer>(serial_incr_analyzer);
+
+        float serial_incr_verify_time = 0;
+        size_t serial_incr_tags_verified = 0;
+        std::map<std::string,std::vector<double>> serial_incr_prof_data;
+        {
+            cout << "Running SerialIncr Analysis " << args.num_serial_incr_runs << " times" << endl;
+
+            //Analyze
+            serial_incr_prof_data = profile(args.num_serial_incr_runs, serial_incr_analyzer);
+
+            //Verify
+            clock_gettime(CLOCK_MONOTONIC, &verify_start);
+
+            if (args.verify) {
+                cout << "\n";
+                auto res = verify_analyzer(*timing_graph, serial_incr_analyzer, *golden_reference);
+
+                serial_incr_tags_verified = res.first;
+
+                if(!res.second) {
+                    cout << "Verification failed!\n";
+                    exit_code = 1;
+                }
+            }
+
+            clock_gettime(CLOCK_MONOTONIC, &verify_end);
+            serial_incr_verify_time += tatum::time_sec(verify_start, verify_end);
+
+            cout << endl;
+            cout << "SerialIncr Analysis took " << std::setprecision(6) << std::setw(6) << arithmean(serial_incr_prof_data["analysis_sec"])*args.num_serial_incr_runs << " sec";
+            if(serial_incr_prof_data["analysis_sec"].size() > 0) {
+                cout << " AVG: " << arithmean(serial_incr_prof_data["analysis_sec"]);
+                cout << " Median: " << median(serial_incr_prof_data["analysis_sec"]);
+                cout << " Min: " << *std::min_element(serial_incr_prof_data["analysis_sec"].begin(), serial_incr_prof_data["analysis_sec"].end());
+                cout << " Max: " << *std::max_element(serial_incr_prof_data["analysis_sec"].begin(), serial_incr_prof_data["analysis_sec"].end());
+            }
+            cout << endl;
+
+            cout << "\tReset             Median: " << std::setprecision(6) << std::setw(6) << median(serial_incr_prof_data["reset_sec"]) << " s";
+            cout << " (" << std::setprecision(2) << median(serial_incr_prof_data["reset_sec"])/median(serial_incr_prof_data["analysis_sec"]) << ")" << endl;
+
+            cout << "\tArr Pre-traversal Median: " << std::setprecision(6) << std::setw(6) << median(serial_incr_prof_data["arrival_pre_traversal_sec"]) << " s";
+            cout << " (" << std::setprecision(2) << median(serial_incr_prof_data["arrival_pre_traversal_sec"])/median(serial_incr_prof_data["analysis_sec"]) << ")" << endl;
+
+            cout << "\tReq Pre-traversal Median: " << std::setprecision(6) << std::setw(6) << median(serial_incr_prof_data["required_pre_traversal_sec"]) << " s";
+            cout << " (" << std::setprecision(2) << median(serial_incr_prof_data["required_pre_traversal_sec"])/median(serial_incr_prof_data["analysis_sec"]) << ")" << endl;
+
+            cout << "\tArr     traversal Median: " << std::setprecision(6) << std::setw(6) << median(serial_incr_prof_data["arrival_traversal_sec"]) << " s";
+            cout << " (" << std::setprecision(2) << median(serial_incr_prof_data["arrival_traversal_sec"])/median(serial_incr_prof_data["analysis_sec"]) << ")" << endl;
+
+            cout << "\tReq     traversal Median: " << std::setprecision(6) << std::setw(6) << median(serial_incr_prof_data["required_traversal_sec"]) << " s";
+            cout << " (" << std::setprecision(2) << median(serial_incr_prof_data["required_traversal_sec"])/median(serial_incr_prof_data["analysis_sec"]) << ")" << endl;
+
+            cout << "\tUpdate slack      Median: " << std::setprecision(6) << std::setw(6) << median(serial_incr_prof_data["update_slack_sec"]) << " s";
+            cout << " (" << std::setprecision(2) << median(serial_incr_prof_data["update_slack_sec"])/median(serial_incr_prof_data["analysis_sec"]) << ")" << endl;
+
+            cout << "Verifying SerialIncr Analysis took: " <<  serial_incr_verify_time<< " sec" << endl;
+            if(serial_incr_tags_verified != golden_reference->num_tags() && serial_incr_tags_verified != golden_reference->num_tags()/2) {
+                //Potentially alow / 2 for setup only analysis from setup/hold golden
+                cout << "WARNING: Expected tags (" << golden_reference->num_tags() << ") differs from tags checked (" << serial_tags_verified << ") , verification may not have occured!" << endl;
+            } else {
+                cout << "\tVerified " << serial_tags_verified << " tags (expected " << golden_reference->num_tags() << " or " << golden_reference->num_tags()/2 << ") accross " << timing_graph->nodes().size() << " nodes" << endl;
+            }
+        }
+        cout << endl;
+
+
+        cout << "SerialIncr Speed-Up: " << std::fixed << median(serial_prof_data["analysis_sec"]) / median(serial_incr_prof_data["analysis_sec"]) << "x" << endl;
+        cout << "\t            Reset: " << std::fixed << median(serial_prof_data["reset_sec"]) / median(serial_incr_prof_data["reset_sec"]) << "x" << endl;
+        cout << "\tArr Pre-traversal: " << std::fixed << median(serial_prof_data["arrival_pre_traversal_sec"]) / median(serial_incr_prof_data["arrival_pre_traversal_sec"]) << "x" << endl;
+        cout << "\tReq Pre-traversal: " << std::fixed << median(serial_prof_data["required_pre_traversal_sec"]) / median(serial_incr_prof_data["required_pre_traversal_sec"]) << "x" << endl;
+        cout << "\t    Arr-traversal: " << std::fixed << median(serial_prof_data["arrival_traversal_sec"]) / median(serial_incr_prof_data["arrival_traversal_sec"]) << "x" << endl;
+        cout << "\t    Req-traversal: " << std::fixed << median(serial_prof_data["required_traversal_sec"]) / median(serial_incr_prof_data["required_traversal_sec"]) << "x" << endl;
+        cout << "\t     Update-slack: " << std::fixed << median(serial_prof_data["update_slack_sec"]) / median(serial_incr_prof_data["update_slack_sec"]) << "x" << endl;
+        cout << endl;
+
+        cout << endl << "Net SerialIncr Analysis elapsed time: " << serial_incr_analyzer->get_profiling_data("total_analysis_sec") << " sec over " << serial_incr_analyzer->get_profiling_data("num_full_updates") << " full updates" << endl;
+    }
 
     if (args.num_parallel_runs) {
         std::shared_ptr<tatum::TimingAnalyzer> parallel_analyzer = tatum::AnalyzerFactory<tatum::SetupHoldAnalysis,tatum::ParallelWalker>::make(*timing_graph, *timing_constraints, *delay_calculator);

--- a/tatum_test/profile.cpp
+++ b/tatum_test/profile.cpp
@@ -117,7 +117,7 @@ bool profile_incr(size_t num_iterations,
                 size_t iedge = uniform_distr(rng);
                 tatum::EdgeId edge(iedge);
 
-#if 1
+#if 0
                 //Avoid changing clock edges
                 while(clk_edges.count(edge)) {
                     size_t iedge2 = uniform_distr(rng);

--- a/tatum_test/profile.cpp
+++ b/tatum_test/profile.cpp
@@ -80,7 +80,7 @@ std::map<std::string,std::vector<double>> profile_rand_incr(size_t num_iteration
         if (i > 0) {
             //Randomly invalidate edges
 
-            size_t EDGES_TO_INVALIDATE = 0.001 * tg.edges().size();
+            size_t EDGES_TO_INVALIDATE = 0.01 * tg.edges().size();
             for (size_t j = 0; j < EDGES_TO_INVALIDATE; j++) {
                 size_t iedge = uniform_distr(rng);
                 tatum::EdgeId edge(iedge);

--- a/tatum_test/profile.cpp
+++ b/tatum_test/profile.cpp
@@ -146,6 +146,10 @@ bool profile_incr(size_t num_iterations,
 #ifdef TATUM_TEST_PROFILE_CALLGRIND
         CALLGRIND_TOGGLE_COLLECT;
         std::cout << "Toggle Collect (End)\n";
+        std::stringstream ss;
+        ss << "incr_update" << i;
+        std::cout << "Callgrind Dump Stats " << ss.str() << "\n";
+        CALLGRIND_DUMP_STATS_AT(ss.str().c_str());
 #endif
         ref_analyzer->update_timing();
 
@@ -178,8 +182,6 @@ bool profile_incr(size_t num_iterations,
     }
 
 #ifdef TATUM_TEST_PROFILE_CALLGRIND
-    std::cout << "Callgrind Dump Stats\n";
-    CALLGRIND_DUMP_STATS;
     std::cout << "Callgrind Stop Instrumentation\n";
     CALLGRIND_STOP_INSTRUMENTATION;
 #endif

--- a/tatum_test/profile.cpp
+++ b/tatum_test/profile.cpp
@@ -1,7 +1,10 @@
 #include <iostream>
 #include <cmath>
 #include <chrono>
+#include <random>
 #include "profile.hpp"
+
+#include "tatum/TimingGraph.hpp"
 
 #ifdef TATUM_STA_PROFILE_VTUNE
 #include "ittnotify.h"
@@ -58,6 +61,58 @@ std::map<std::string,std::vector<double>> profile(size_t num_iterations, std::sh
 #ifdef TATUM_STA_PROFILE_CALLGRIND
     CALLGRIND_STOP_INSTRUMENTATION;
 #endif
+
+    return prof_data;
+}
+
+std::map<std::string,std::vector<double>> profile_rand_incr(size_t num_iterations, std::shared_ptr<tatum::TimingAnalyzer> serial_analyzer, tatum::FixedDelayCalculator& delay_calc, const tatum::TimingGraph& tg) {
+
+    std::map<std::string,std::vector<double>> prof_data;
+
+    std::minstd_rand rng;
+    std::uniform_int_distribution<size_t> uniform_distr(0, tg.edges().size() - 1);
+    std::normal_distribution<float> normal_distr(0, 1e-9);
+
+    for(size_t i = 0; i < num_iterations; i++) {
+
+        if (i > 0) {
+            //Randomly invalidate edges
+
+            size_t EDGES_TO_INVALIDATE = 0.001 * tg.edges().size();
+            for (size_t j = 0; j < EDGES_TO_INVALIDATE; j++) {
+                size_t iedge = uniform_distr(rng);
+                tatum::EdgeId edge(iedge);
+
+                //Invalidate
+                serial_analyzer->invalidate_edge(edge);
+
+                //Set new delays
+                if (tg.edge_type(edge) == tatum::EdgeType::PRIMITIVE_CLOCK_CAPTURE) {
+                    float new_setup = std::max<float>(0, delay_calc.setup_time(tg, edge).value() + normal_distr(rng));
+                    float new_hold = std::max<float>(0, delay_calc.hold_time(tg, edge).value() + normal_distr(rng));
+                    delay_calc.set_setup_time(tg, edge, tatum::Time(new_setup));
+                    delay_calc.set_hold_time(tg, edge, tatum::Time(new_hold));
+                } else {
+                    float new_max = std::max<float>(0, delay_calc.max_edge_delay(tg, edge).value() + normal_distr(rng));
+                    float new_min = std::max<float>(0, delay_calc.min_edge_delay(tg, edge).value() + normal_distr(rng));
+                    delay_calc.set_max_edge_delay(tg, edge, tatum::Time(new_max));
+                    delay_calc.set_min_edge_delay(tg, edge, tatum::Time(new_min));
+                }
+            }
+        }
+
+        //Analyze
+        serial_analyzer->update_timing();
+
+
+        for(auto key : {"arrival_pre_traversal_sec", "arrival_traversal_sec", "required_pre_traversal_sec", "required_traversal_sec", "reset_sec", "update_slack_sec", "analysis_sec"}) {
+            prof_data[key].push_back(serial_analyzer->get_profiling_data(key));
+        }
+
+
+        std::cout << ".";
+        std::cout.flush();
+    }
 
     return prof_data;
 }

--- a/tatum_test/profile.hpp
+++ b/tatum_test/profile.hpp
@@ -6,10 +6,11 @@
 #include <memory>
 
 #include "tatum/timing_analyzers.hpp"
+#include "tatum/TimingConstraints.hpp"
 #include "tatum/delay_calc/FixedDelayCalculator.hpp"
 
 std::map<std::string,std::vector<double>> profile(size_t num_iterations, std::shared_ptr<tatum::TimingAnalyzer> serial_analyzer);
 
-std::map<std::string,std::vector<double>> profile_rand_incr(size_t num_iterations, std::shared_ptr<tatum::TimingAnalyzer> serial_analyzer, tatum::FixedDelayCalculator& delay_calc, const tatum::TimingGraph& tg);
+std::map<std::string,std::vector<double>> profile_rand_incr(size_t num_iterations, std::shared_ptr<tatum::TimingAnalyzer> check_analyzer, std::shared_ptr<tatum::TimingAnalyzer> ref_analyzer, tatum::FixedDelayCalculator& delay_calc, const tatum::TimingGraph& tg, const tatum::TimingConstraints& tc);
 
 #endif

--- a/tatum_test/profile.hpp
+++ b/tatum_test/profile.hpp
@@ -10,6 +10,13 @@
 
 std::map<std::string,std::vector<double>> profile(size_t num_iterations, std::shared_ptr<tatum::TimingAnalyzer> serial_analyzer);
 
-std::map<std::string,std::vector<double>> profile_rand_incr(size_t num_iterations, float edge_change_prob, std::shared_ptr<tatum::TimingAnalyzer> check_analyzer, std::shared_ptr<tatum::TimingAnalyzer> ref_analyzer, tatum::FixedDelayCalculator& delay_calc, const tatum::TimingGraph& tg);
+bool profile_incr(size_t num_iterations,
+                  float edge_change_prob,
+                  bool verify,
+                  const tatum::TimingGraph& tg,
+                  std::shared_ptr<tatum::TimingAnalyzer> check_analyzer,
+                  std::shared_ptr<tatum::TimingAnalyzer> ref_analyzer,
+                  tatum::FixedDelayCalculator& delay_calc,
+                  std::map<std::string,std::vector<double>>& prof_data);
 
 #endif

--- a/tatum_test/profile.hpp
+++ b/tatum_test/profile.hpp
@@ -6,11 +6,10 @@
 #include <memory>
 
 #include "tatum/timing_analyzers.hpp"
-#include "tatum/TimingConstraints.hpp"
 #include "tatum/delay_calc/FixedDelayCalculator.hpp"
 
 std::map<std::string,std::vector<double>> profile(size_t num_iterations, std::shared_ptr<tatum::TimingAnalyzer> serial_analyzer);
 
-std::map<std::string,std::vector<double>> profile_rand_incr(size_t num_iterations, std::shared_ptr<tatum::TimingAnalyzer> check_analyzer, std::shared_ptr<tatum::TimingAnalyzer> ref_analyzer, tatum::FixedDelayCalculator& delay_calc, const tatum::TimingGraph& tg, const tatum::TimingConstraints& tc);
+std::map<std::string,std::vector<double>> profile_rand_incr(size_t num_iterations, float edge_change_prob, std::shared_ptr<tatum::TimingAnalyzer> check_analyzer, std::shared_ptr<tatum::TimingAnalyzer> ref_analyzer, tatum::FixedDelayCalculator& delay_calc, const tatum::TimingGraph& tg);
 
 #endif

--- a/tatum_test/profile.hpp
+++ b/tatum_test/profile.hpp
@@ -6,7 +6,10 @@
 #include <memory>
 
 #include "tatum/timing_analyzers.hpp"
+#include "tatum/delay_calc/FixedDelayCalculator.hpp"
 
 std::map<std::string,std::vector<double>> profile(size_t num_iterations, std::shared_ptr<tatum::TimingAnalyzer> serial_analyzer);
+
+std::map<std::string,std::vector<double>> profile_rand_incr(size_t num_iterations, std::shared_ptr<tatum::TimingAnalyzer> serial_analyzer, tatum::FixedDelayCalculator& delay_calc, const tatum::TimingGraph& tg);
 
 #endif

--- a/tatum_test/verify.cpp
+++ b/tatum_test/verify.cpp
@@ -145,6 +145,7 @@ std::pair<size_t,bool> verify_equivalent_analysis(const TimingGraph& tg, const D
 
     auto dot_writer = make_graphviz_dot_writer(tg, dc);
 
+    NodeId error_node;
 
 
     for(LevelId level : tg.levels()) {
@@ -193,17 +194,20 @@ std::pair<size_t,bool> verify_equivalent_analysis(const TimingGraph& tg, const D
 
 
 
-            if (error) {
-                std::vector<tatum::NodeId> nodes = find_transitively_connected_nodes(tg, {node});
-                dot_writer.set_nodes_to_dump(nodes);
-
-                dot_writer.write_dot_file("check_tg_setup_annotated.dot", *setup_check_analyzer);
-                dot_writer.write_dot_file("ref_tg_setup_annotated.dot", *setup_ref_analyzer);
-                dot_writer.write_dot_file("check_tg_hold_annotated.dot", *hold_check_analyzer);
-                dot_writer.write_dot_file("ref_tg_hold_annotated.dot", *hold_ref_analyzer);
-                exit(1);
-            }
         }
+    }
+
+    if (error) {
+        std::cout << "Dumping dot\n";
+        //std::vector<tatum::NodeId> nodes = find_transitively_connected_nodes(tg, {NodeId(5133)});
+        const auto& tg_nodes = tg.nodes();
+        std::vector<tatum::NodeId> nodes(tg_nodes.begin(), tg_nodes.end());
+        dot_writer.set_nodes_to_dump(nodes);
+
+        dot_writer.write_dot_file("check_tg_setup_annotated.dot", *setup_check_analyzer);
+        dot_writer.write_dot_file("ref_tg_setup_annotated.dot", *setup_ref_analyzer);
+        dot_writer.write_dot_file("check_tg_hold_annotated.dot", *hold_check_analyzer);
+        dot_writer.write_dot_file("ref_tg_hold_annotated.dot", *hold_ref_analyzer);
     }
 
     return {tags_checked,!error};

--- a/tatum_test/verify.cpp
+++ b/tatum_test/verify.cpp
@@ -54,6 +54,10 @@ std::pair<size_t,bool> verify_analyzer(const TimingGraph& tg, std::shared_ptr<Ti
                 res = verify_node_tags(node, setup_analyzer->setup_tags(node, TagType::CLOCK_CAPTURE), gr.get_result(node, tatumparse::TagType::SETUP_CAPTURE_CLOCK), "setup_capture_clock");
                 tags_checked += res.first;
                 error |= res.second;
+
+                res = verify_node_tags(node, setup_analyzer->setup_tags(node, TagType::SLACK), gr.get_result(node, tatumparse::TagType::SETUP_SLACK), "setup_slack");
+                tags_checked += res.first;
+                error |= res.second;
             }
             if(hold_analyzer) {
                 auto res = verify_node_tags(node, hold_analyzer->hold_tags(node, TagType::DATA_ARRIVAL), gr.get_result(node, tatumparse::TagType::HOLD_DATA_ARRIVAL), "hold_data_arrival");
@@ -69,6 +73,10 @@ std::pair<size_t,bool> verify_analyzer(const TimingGraph& tg, std::shared_ptr<Ti
                 error |= res.second;
 
                 res = verify_node_tags(node, hold_analyzer->hold_tags(node, TagType::CLOCK_CAPTURE), gr.get_result(node, tatumparse::TagType::HOLD_CAPTURE_CLOCK), "hold_capture_clock");
+                tags_checked += res.first;
+                error |= res.second;
+
+                res = verify_node_tags(node, hold_analyzer->hold_tags(node, TagType::SLACK), gr.get_result(node, tatumparse::TagType::HOLD_SLACK), "hold_slack");
                 tags_checked += res.first;
                 error |= res.second;
             }
@@ -170,6 +178,10 @@ std::pair<size_t,bool> verify_equivalent_analysis(const TimingGraph& tg, const D
                 res = verify_node_tags(node, setup_check_analyzer->setup_tags(node, TagType::CLOCK_CAPTURE), setup_ref_analyzer->setup_tags(node, TagType::CLOCK_CAPTURE), "setup_capture_clock");
                 tags_checked += res.first;
                 error |= res.second;
+
+                res = verify_node_tags(node, setup_check_analyzer->setup_slacks(node), setup_ref_analyzer->setup_slacks(node), "setup_slack");
+                tags_checked += res.first;
+                error |= res.second;
             }
 
             if(hold_ref_analyzer) {
@@ -188,6 +200,10 @@ std::pair<size_t,bool> verify_equivalent_analysis(const TimingGraph& tg, const D
                 error |= res.second;
 
                 res = verify_node_tags(node, hold_check_analyzer->hold_tags(node, TagType::CLOCK_CAPTURE), hold_ref_analyzer->hold_tags(node, TagType::CLOCK_CAPTURE), "hold_capture_clock");
+                tags_checked += res.first;
+                error |= res.second;
+
+                res = verify_node_tags(node, hold_check_analyzer->hold_slacks(node), hold_ref_analyzer->hold_slacks(node), "hold_slack");
                 tags_checked += res.first;
                 error |= res.second;
             }

--- a/tatum_test/verify.cpp
+++ b/tatum_test/verify.cpp
@@ -279,7 +279,9 @@ bool verify_time(NodeId node, DomainId launch_domain, DomainId capture_domain, f
         //
         //This occurs in some cases (such as applying clock tags to primary outputs)
         //which are cuased by the differeing analysis methods
-    } else if (std::isnan(analyzer_time) && std::isnan(reference_time)) {
+    } else if ((std::isnan(analyzer_time) && std::isnan(reference_time)) //Both NaN
+               || (std::isinf(analyzer_time) && std::isinf(reference_time) //Both inf with same sign
+                   && (std::signbit(analyzer_time) == std::signbit(reference_time)))) {
         //They agree, pass
     } else if(arr_rel_err > RELATIVE_EPSILON && arr_abs_err > ABSOLUTE_EPSILON) {
         cout << "Node: " << node << " Launch Clk: " << launch_domain << " Capture Clk: " << capture_domain;

--- a/tatum_test/verify.cpp
+++ b/tatum_test/verify.cpp
@@ -77,18 +77,10 @@ std::pair<size_t,bool> verify_node_tags(const NodeId node, TimingTags::tag_range
     //Check that every tag in the analyzer matches the reference results
     size_t tags_verified = 0;
     for(const TimingTag& tag : analyzer_tags) {
-        DomainId domain;
-        if(tag.type() == TagType::CLOCK_LAUNCH || tag.type() == TagType::DATA_ARRIVAL || tag.type() == TagType::DATA_REQUIRED) {
-            domain = tag.launch_clock_domain();
-        } else {
-            TATUM_ASSERT(tag.type() == TagType::CLOCK_CAPTURE);
-            domain = tag.capture_clock_domain();
-        }
-
         auto iter = ref_results.find({tag.launch_clock_domain(), tag.capture_clock_domain()});
         if(iter == ref_results.end()) {
             cout << "Node: " << node << " Type: " << type << endl;
-            cout << "\tERROR No reference tag found for clock domain " << tag.launch_clock_domain() << endl;
+            cout << "\tERROR No reference tag found for clock domain pair " << tag.launch_clock_domain() << ", " << tag.capture_clock_domain() << endl;
             error = true;
         } else {
             if(!verify_tag(tag, iter->second)) {
@@ -136,7 +128,7 @@ bool verify_tag(const TimingTag& tag, const TagResult& ref_result) {
 bool verify_time(NodeId node, DomainId launch_domain, DomainId capture_domain, float analyzer_time, float reference_time) {
     float arr_abs_err = fabs(analyzer_time - reference_time);
     float arr_rel_err = relative_error(analyzer_time, reference_time);
-    if(std::isnan(analyzer_time) && std::isnan(analyzer_time) != std::isnan(reference_time)) {
+    if(std::isnan(analyzer_time) && (std::isnan(analyzer_time) != std::isnan(reference_time))) {
         cout << "Node: " << node << " Launch Clk: " << launch_domain << " Capture Clk: " << capture_domain;
         cout << " Calc: " << analyzer_time;
         cout << " Ref: " << reference_time << endl;

--- a/tatum_test/verify.cpp
+++ b/tatum_test/verify.cpp
@@ -215,15 +215,18 @@ std::pair<size_t,bool> verify_equivalent_analysis(const TimingGraph& tg, const D
 
     if (error) {
         std::cout << "Dumping dot\n";
-        //std::vector<tatum::NodeId> nodes = find_transitively_connected_nodes(tg, {NodeId(5133)});
+#if 0
+        std::vector<tatum::NodeId> nodes = find_transitively_connected_nodes(tg, {NodeId(4630)});
+#else
         const auto& tg_nodes = tg.nodes();
         std::vector<tatum::NodeId> nodes(tg_nodes.begin(), tg_nodes.end());
+#endif
         dot_writer.set_nodes_to_dump(nodes);
 
-        dot_writer.write_dot_file("check_tg_setup_annotated.dot", *setup_check_analyzer);
-        dot_writer.write_dot_file("ref_tg_setup_annotated.dot", *setup_ref_analyzer);
-        dot_writer.write_dot_file("check_tg_hold_annotated.dot", *hold_check_analyzer);
-        dot_writer.write_dot_file("ref_tg_hold_annotated.dot", *hold_ref_analyzer);
+        if (setup_check_analyzer) dot_writer.write_dot_file("check_tg_setup_annotated.dot", *setup_check_analyzer);
+        if (setup_ref_analyzer) dot_writer.write_dot_file("ref_tg_setup_annotated.dot", *setup_ref_analyzer);
+        if (hold_check_analyzer) dot_writer.write_dot_file("check_tg_hold_annotated.dot", *hold_check_analyzer);
+        if (hold_ref_analyzer) dot_writer.write_dot_file("ref_tg_hold_annotated.dot", *hold_ref_analyzer);
     }
 
     return {tags_checked,!error};

--- a/tatum_test/verify.hpp
+++ b/tatum_test/verify.hpp
@@ -4,8 +4,11 @@
 
 #include "tatum/timing_analyzers_fwd.hpp"
 #include "tatum/TimingGraphFwd.hpp"
+#include "tatum/delay_calc/DelayCalculator.hpp"
 #include "golden_reference.hpp"
 
 std::pair<size_t,bool> verify_analyzer(const tatum::TimingGraph& tg, std::shared_ptr<tatum::TimingAnalyzer> analyzer, GoldenReference& gr);
+
+std::pair<size_t,bool> verify_equivalent_analysis(const tatum::TimingGraph& tg, const tatum::DelayCalculator& dc, std::shared_ptr<tatum::TimingAnalyzer> ref_analyzer,  std::shared_ptr<tatum::TimingAnalyzer> check_analyzer);
 
 #endif


### PR DESCRIPTION
Adds API for edge invalidation: `TimingAnalyzer::invalidate_edge()`, which is used by the client (i.e. CAD tool) to indicate a timing graph edge has been invalidated and the associated nodes need to be re-evaluated. Subsequent calls to `TimingAnalyzer::update_timing()` will incrementally update all effected timing nodes and tags based on the new delays (for those edges which have been invalidated) returned by calls to the delay calculator. The client can then also retrieve the set of modified nodes with `TimingAnalyzer::modified_nodes()`.

Also adds `SerialIncrWalker` which implements the incremental traversals leveraging the existing GraphVisitor methods.